### PR TITLE
Github actions: Remove android-33-ext5 from build image

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -63,8 +63,10 @@ jobs:
           ndk-version: r21e
           add-to-path: false
 
-      - name: Remove Android SDK android-33-ext4
-        run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
+      - name: Remove Android SDK android-33-ext
+        run: |
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext5"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir


### PR DESCRIPTION
Github workflow image ubuntu-20.04 version 20230313.1 have added Android SDK Platform android-33-ext5. Something, possible the gradle version bundled with qt does not parse this correctly, and sets androidCompileSdkVersion in android-build/gradle.properties to "ext5" instead of expected "33". This commit is a quick fix to the problem, so the build will revert to android-33 which was used before 20230109.1.

This fix was previously added for android-33-ext4 in image 20230109.1 #11.

The documentation for the added package in the image version can be found here:
https://github.com/actions/runner-images/pull/7278

Note: Currently 20230313.1 is in progress of being rolled out, making which builds that failes or not pseudo-random.
