### PR TITLE
Stop hiding "Continue Mission" action for the two last mission items

### DIFF
--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -114,7 +114,7 @@ Item {
     property bool showTakeoff:          _guidedActionsEnabled && _activeVehicle.takeoffVehicleSupported && !_vehicleFlying && _canArm
     property bool showLand:             _guidedActionsEnabled && _activeVehicle.guidedModeSupported && _vehicleArmed && !_activeVehicle.fixedWing && !_vehicleInLandMode
     property bool showStartMission:     _guidedActionsEnabled && _missionAvailable && !_missionActive && !_vehicleFlying && _canArm
-    property bool showContinueMission:  _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying && (_currentMissionIndex < _missionItemCount - 1)
+    property bool showContinueMission:  _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying
     property bool showPause:            _guidedActionsEnabled && _vehicleArmed && _activeVehicle.pauseVehicleSupported && _vehicleFlying && !_vehiclePaused && !_fixedWingOnApproach
     property bool showChangeAlt:        _guidedActionsEnabled && _vehicleFlying && _activeVehicle.guidedModeSupported && _vehicleArmed && !_missionActive
     property bool showOrbit:            _guidedActionsEnabled && _vehicleFlying && __orbitSupported && !_missionActive


### PR DESCRIPTION
It looks to me like:
1. https://github.com/mavlink/qgroundcontrol/pull/5066 hid the "Continue Mission" action on the last mission item.
2. https://github.com/mavlink/qgroundcontrol/commit/82cceb1ae7 changed from `missionController.visualItems.count` to `_missionItemCount` in order to fix https://github.com/mavlink/qgroundcontrol/issues/6835. This also introduced a new bug, hiding the action for the second last mission item.

This PR removes the mission item index check completely here since we want the "Continue Mission" action to be available for the last mission item as well.
