### PR TITLE
[BACKPORT]QGCCommon: Disable AIRMAP & qmlglsink: Update to the latest version

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -20,7 +20,9 @@ CONFIG -= debug_and_release
 CONFIG += warn_on
 CONFIG += resources_big
 CONFIG += c++17
-    
+
+DEFINES += DISABLE_AIRMAP # AIRMAP SDK does not exist anymore
+
 linux {
     linux-g++ | linux-g++-64 | linux-g++-32 | linux-clang {
         message("Linux build")


### PR DESCRIPTION
Backport of these two PRs to resolve build issues:

https://github.com/mavlink/qgroundcontrol/pull/10132 
Fix issue:
`error: argument 2 of ‘__atomic_load’ must not be a pointer to a ‘volatile’ type`

https://github.com/mavlink/qgroundcontrol/pull/10729
Fix the issue with airmap. 