### PR TITLE
Add support for geofences with individual actions and maximum altitude

### DIFF
--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -495,9 +495,19 @@ void GeoFenceController::setPolygonFenceAction(int index, int fenceAction)
     _polygons.value<QGCFencePolygon*>(index)->setFenceAction(fenceAction);
 }
 
+void GeoFenceController::setPolygonMaxAltitude(int index, int maxAltitude)
+{
+    _polygons.value<QGCFencePolygon*>(index)->setMaxAltitude(maxAltitude);
+}
+
 void GeoFenceController::setCircleFenceAction(int index, int fenceAction)
 {
     _circles.value<QGCFenceCircle*>(index)->setFenceAction(fenceAction);
+}
+
+void GeoFenceController::setCircleMaxAltitude(int index, int maxAltitude)
+{
+    _circles.value<QGCFenceCircle*>(index)->setMaxAltitude(maxAltitude);
 }
 
 bool GeoFenceController::supported(void) const

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -490,6 +490,16 @@ void GeoFenceController::clearAllInteractive(void)
     }
 }
 
+void GeoFenceController::setPolygonFenceAction(int index, int fenceAction)
+{
+    _polygons.value<QGCFencePolygon*>(index)->setFenceAction(fenceAction);
+}
+
+void GeoFenceController::setCircleFenceAction(int index, int fenceAction)
+{
+    _circles.value<QGCFenceCircle*>(index)->setFenceAction(fenceAction);
+}
+
 bool GeoFenceController::supported(void) const
 {
     return (_managerVehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_MISSION_FENCE) && (_managerVehicle->maxProtoVersion() >= 200);

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -18,6 +18,10 @@
 #include "MultiVehicleManager.h"
 #include "QGCLoggingCategory.h"
 
+#define SHARED_CONSTANT(type, name, value) \
+static inline const type name = value; \
+    Q_PROPERTY(type name MEMBER name CONSTANT)
+
 Q_DECLARE_LOGGING_CATEGORY(GeoFenceControllerLog)
 
 class GeoFenceManager;
@@ -29,6 +33,13 @@ class GeoFenceController : public PlanElementController
 public:
     GeoFenceController(PlanMasterController* masterController, QObject* parent = nullptr);
     ~GeoFenceController();
+
+    SHARED_CONSTANT(QString, NONE, QStringLiteral("None"));
+    SHARED_CONSTANT(QString, WARN, QStringLiteral("Warn"));
+    SHARED_CONSTANT(QString, HOLD, QStringLiteral("Hold"));
+    SHARED_CONSTANT(QString, RTL, QStringLiteral("RTL"));
+    SHARED_CONSTANT(QString, LAND, QStringLiteral("Land"));
+    SHARED_CONSTANT(QString, TERMINATE, QStringLiteral("Terminate"));
 
     Q_PROPERTY(QmlObjectListModel*  polygons                READ polygons                                           CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  circles                 READ circles                                            CONSTANT)
@@ -58,6 +69,26 @@ public:
 
     /// Clears the interactive bit from all fence items
     Q_INVOKABLE void clearAllInteractive(void);
+
+    /// Get polygon fence action
+    ///     @param index: index of poygon
+    ///     @return fenceAction
+    Q_INVOKABLE int getPolygonFenceAction(int index) { return _polygons.value<QGCFencePolygon*>(index)->fenceAction(); }
+
+    /// Get circle fence action
+    ///     @param index: index of circle
+    ///     @return fenceAction
+    Q_INVOKABLE int getCircleFenceAction(int index) { return _circles.value<QGCFenceCircle*>(index)->fenceAction(); }
+
+    /// Set polygon fence action
+    ///     @param index: index of poygon
+    ///     @param fenceAction: action to apply for this fence
+    Q_INVOKABLE void setPolygonFenceAction(int index, int fenceAction);
+
+    /// Set circle fence action
+    ///     @param index: index of circle
+    ///     @param fenceAction: action to apply for this fence
+    Q_INVOKABLE void setCircleFenceAction(int index, int fenceAction);
 
     double  paramCircularFence  (void);
     Fact*   breachReturnAltitude(void) { return &_breachReturnAltitudeFact; }

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -34,6 +34,7 @@ public:
     GeoFenceController(PlanMasterController* masterController, QObject* parent = nullptr);
     ~GeoFenceController();
 
+    SHARED_CONSTANT(QString, DEFAULT, QStringLiteral("Default"));
     SHARED_CONSTANT(QString, NONE, QStringLiteral("None"));
     SHARED_CONSTANT(QString, WARN, QStringLiteral("Warn"));
     SHARED_CONSTANT(QString, HOLD, QStringLiteral("Hold"));

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -75,20 +75,40 @@ public:
     ///     @return fenceAction
     Q_INVOKABLE int getPolygonFenceAction(int index) { return _polygons.value<QGCFencePolygon*>(index)->fenceAction(); }
 
+    /// Get polygon maximum altitude
+    ///     @param index: index of poygon
+    ///     @return maxAltitude
+    Q_INVOKABLE int getPolygonMaxAltitude(int index) { return _polygons.value<QGCFencePolygon*>(index)->maxAltitude(); }
+
     /// Get circle fence action
     ///     @param index: index of circle
     ///     @return fenceAction
     Q_INVOKABLE int getCircleFenceAction(int index) { return _circles.value<QGCFenceCircle*>(index)->fenceAction(); }
+
+    /// Get circle maximum altitude
+    ///     @param index: index of circle
+    ///     @return maxAltitude
+    Q_INVOKABLE int getCircleMaxAltitude(int index) { return _circles.value<QGCFenceCircle*>(index)->maxAltitude(); };
 
     /// Set polygon fence action
     ///     @param index: index of poygon
     ///     @param fenceAction: action to apply for this fence
     Q_INVOKABLE void setPolygonFenceAction(int index, int fenceAction);
 
+    /// Set polygon maximum altitude
+    ///     @param index: index of poygon
+    ///     @param maxAltitude: maximum altitude for this fence
+    Q_INVOKABLE void setPolygonMaxAltitude(int index, int maxAltitude);
+
     /// Set circle fence action
     ///     @param index: index of circle
     ///     @param fenceAction: action to apply for this fence
     Q_INVOKABLE void setCircleFenceAction(int index, int fenceAction);
+
+    /// Set circle maximum altitude
+    ///     @param index: index of circle
+    ///     @param maxAltitude: maximum altitude for this fence
+    Q_INVOKABLE void setCircleMaxAltitude(int index, int maxAltitude);
 
     double  paramCircularFence  (void);
     Fact*   breachReturnAltitude(void) { return &_breachReturnAltitudeFact; }

--- a/src/MissionManager/GeoFenceManager.cc
+++ b/src/MissionManager/GeoFenceManager.cc
@@ -67,7 +67,7 @@ void GeoFenceManager::sendToVehicle(const QGeoCoordinate&   breachReturn,
                                                 0,                  // param 4 unused
                                                 vertex.latitude(),
                                                 vertex.longitude(),
-                                                0,                  // param 7 unused
+                                                static_cast<double>(polygon.maxAltitude()),  // param 7
                                                 false,              // autocontinue
                                                 false,              // isCurrentItem
                                                 this);              // parent
@@ -87,7 +87,7 @@ void GeoFenceManager::sendToVehicle(const QGeoCoordinate&   breachReturn,
                                             0,                          // param 4 unused
                                             circle.center().latitude(),
                                             circle.center().longitude(),
-                                            0,                          // param 7 unused
+                                            static_cast<double>(circle.maxAltitude()),  // param 7
                                             false,                      // autocontinue
                                             false,                      // isCurrentItem
                                             this);                      // parent
@@ -174,6 +174,7 @@ void GeoFenceManager::_planManagerLoadComplete(bool removeAllRequested)
                 // Polygon is complete
                 nextPolygon.setInclusion(command == MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION);
                 nextPolygon.setFenceAction(static_cast<int>(item->param3()));
+                nextPolygon.setMaxAltitude(static_cast<int>(item->param7()));
                 _polygons.append(nextPolygon);
                 nextPolygon.clear();
             }
@@ -185,6 +186,7 @@ void GeoFenceManager::_planManagerLoadComplete(bool removeAllRequested)
             }
             QGCFenceCircle circle(QGeoCoordinate(item->param5(), item->param6()), item->param1(), command == MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION /* inclusion */);
             circle.setFenceAction(static_cast<int>(item->param3()));
+            circle.setMaxAltitude(static_cast<int>(item->param7()));
             _circles.append(circle);
         } else if (command == MAV_CMD_NAV_FENCE_RETURN_POINT) {
             _breachReturnPoint = QGeoCoordinate(item->param5(), item->param6(), item->param7());

--- a/src/MissionManager/GeoFenceManager.cc
+++ b/src/MissionManager/GeoFenceManager.cc
@@ -62,7 +62,9 @@ void GeoFenceManager::sendToVehicle(const QGeoCoordinate&   breachReturn,
                                                 polygon.inclusion() ? MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION : MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION,
                                                 MAV_FRAME_GLOBAL,
                                                 polygon.count(),    // vertex count
-                                                0, 0, 0,            // param 2-4 unused
+                                                0,                  // param 2 reserved (inclusion_group)
+                                                static_cast<double>(polygon.fenceAction()),  // param 3
+                                                0,                  // param 4 unused
                                                 vertex.latitude(),
                                                 vertex.longitude(),
                                                 0,                  // param 7 unused
@@ -80,7 +82,9 @@ void GeoFenceManager::sendToVehicle(const QGeoCoordinate&   breachReturn,
                                             circle.inclusion() ? MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION : MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION,
                                             MAV_FRAME_GLOBAL,
                                             circle.radius()->rawValue().toDouble(),
-                                            0, 0, 0,                    // param 2-4 unused
+                                            0,                          // param 2 reserved (inclusion_group)
+                                            static_cast<double>(circle.fenceAction()),  // param 3
+                                            0,                          // param 4 unused
                                             circle.center().latitude(),
                                             circle.center().longitude(),
                                             0,                          // param 7 unused
@@ -169,6 +173,7 @@ void GeoFenceManager::_planManagerLoadComplete(bool removeAllRequested)
             if (nextPolygon.count() == expectedVertexCount) {
                 // Polygon is complete
                 nextPolygon.setInclusion(command == MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION);
+                nextPolygon.setFenceAction(static_cast<int>(item->param3()));
                 _polygons.append(nextPolygon);
                 nextPolygon.clear();
             }
@@ -179,6 +184,7 @@ void GeoFenceManager::_planManagerLoadComplete(bool removeAllRequested)
                 break;
             }
             QGCFenceCircle circle(QGeoCoordinate(item->param5(), item->param6()), item->param1(), command == MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION /* inclusion */);
+            circle.setFenceAction(static_cast<int>(item->param3()));
             _circles.append(circle);
         } else if (command == MAV_CMD_NAV_FENCE_RETURN_POINT) {
             _breachReturnPoint = QGeoCoordinate(item->param5(), item->param6(), item->param7());

--- a/src/MissionManager/QGCFenceCircle.cc
+++ b/src/MissionManager/QGCFenceCircle.cc
@@ -12,6 +12,7 @@
 
 const char* QGCFenceCircle::_jsonInclusionKey = "inclusion";
 const char* QGCFenceCircle::_jsonFenceActionKey = "fenceAction";
+const char* QGCFenceCircle::_jsonMaxAltitudeKey = "maxAltitude";
 
 QGCFenceCircle::QGCFenceCircle(QObject* parent)
     : QGCMapCircle  (parent)
@@ -31,6 +32,7 @@ QGCFenceCircle::QGCFenceCircle(const QGCFenceCircle& other, QObject* parent)
     : QGCMapCircle  (other, parent)
     , _inclusion    (other._inclusion)
     , _fenceAction  (other._fenceAction)
+    , _maxAltitude  (other._maxAltitude)
 {
     _init();
 }
@@ -46,6 +48,7 @@ const QGCFenceCircle& QGCFenceCircle::operator=(const QGCFenceCircle& other)
 
     setInclusion(other._inclusion);
     setFenceAction(other._fenceAction);
+    setMaxAltitude(other._maxAltitude);
 
     return *this;
 }
@@ -60,6 +63,7 @@ void QGCFenceCircle::saveToJson(QJsonObject& json)
     json[JsonHelper::jsonVersionKey] = _jsonCurrentVersion;
     json[_jsonInclusionKey] = _inclusion;
     json[_jsonFenceActionKey] = _fenceAction;
+    json[_jsonMaxAltitudeKey] = _maxAltitude;
     QGCMapCircle::saveToJson(json);
 }
 
@@ -71,6 +75,7 @@ bool QGCFenceCircle::loadFromJson(const QJsonObject& json, QString& errorString)
         { JsonHelper::jsonVersionKey,   QJsonValue::Double, true },
         { _jsonInclusionKey,            QJsonValue::Bool,   true },
         { _jsonFenceActionKey,          QJsonValue::Double, true },
+        { _jsonMaxAltitudeKey,          QJsonValue::Double, true },
     };
     if (!JsonHelper::validateKeys(json, keyInfoList, errorString)) {
         return false;
@@ -85,19 +90,25 @@ bool QGCFenceCircle::loadFromJson(const QJsonObject& json, QString& errorString)
         return false;
     }
 
+    setMaxAltitude(json[_jsonMaxAltitudeKey].toInt());
     setFenceAction(json[_jsonFenceActionKey].toInt());
-    setInclusion(json[_jsonInclusionKey].toBool());
+    setInclusion(json[_jsonInclusionKey].toBool()); // This will trigger even to change maxAltitude, fenceAction and inclustion
 
     return true;
 }
 
 void QGCFenceCircle::setInclusion(bool inclusion)
 {
-        _inclusion = inclusion;
-        emit inclusionChanged(inclusion);
+    _inclusion = inclusion;
+    emit inclusionChanged(inclusion);
 }
 
 void QGCFenceCircle::setFenceAction (int fenceAction)
 {
     _fenceAction = fenceAction;
+}
+
+void QGCFenceCircle::setMaxAltitude (int maxAltitude)
+{
+    _maxAltitude = maxAltitude;
 }

--- a/src/MissionManager/QGCFenceCircle.cc
+++ b/src/MissionManager/QGCFenceCircle.cc
@@ -11,6 +11,7 @@
 #include "JsonHelper.h"
 
 const char* QGCFenceCircle::_jsonInclusionKey = "inclusion";
+const char* QGCFenceCircle::_jsonFenceActionKey = "fenceAction";
 
 QGCFenceCircle::QGCFenceCircle(QObject* parent)
     : QGCMapCircle  (parent)
@@ -29,6 +30,7 @@ QGCFenceCircle::QGCFenceCircle(const QGeoCoordinate& center, double radius, bool
 QGCFenceCircle::QGCFenceCircle(const QGCFenceCircle& other, QObject* parent)
     : QGCMapCircle  (other, parent)
     , _inclusion    (other._inclusion)
+    , _fenceAction  (other._fenceAction)
 {
     _init();
 }
@@ -43,6 +45,7 @@ const QGCFenceCircle& QGCFenceCircle::operator=(const QGCFenceCircle& other)
     QGCMapCircle::operator=(other);
 
     setInclusion(other._inclusion);
+    setFenceAction(other._fenceAction);
 
     return *this;
 }
@@ -56,6 +59,7 @@ void QGCFenceCircle::saveToJson(QJsonObject& json)
 {
     json[JsonHelper::jsonVersionKey] = _jsonCurrentVersion;
     json[_jsonInclusionKey] = _inclusion;
+    json[_jsonFenceActionKey] = _fenceAction;
     QGCMapCircle::saveToJson(json);
 }
 
@@ -66,6 +70,7 @@ bool QGCFenceCircle::loadFromJson(const QJsonObject& json, QString& errorString)
     QList<JsonHelper::KeyValidateInfo> keyInfoList = {
         { JsonHelper::jsonVersionKey,   QJsonValue::Double, true },
         { _jsonInclusionKey,            QJsonValue::Bool,   true },
+        { _jsonFenceActionKey,          QJsonValue::Double, true },
     };
     if (!JsonHelper::validateKeys(json, keyInfoList, errorString)) {
         return false;
@@ -80,6 +85,7 @@ bool QGCFenceCircle::loadFromJson(const QJsonObject& json, QString& errorString)
         return false;
     }
 
+    setFenceAction(json[_jsonFenceActionKey].toInt());
     setInclusion(json[_jsonInclusionKey].toBool());
 
     return true;
@@ -87,8 +93,11 @@ bool QGCFenceCircle::loadFromJson(const QJsonObject& json, QString& errorString)
 
 void QGCFenceCircle::setInclusion(bool inclusion)
 {
-    if (inclusion != _inclusion) {
         _inclusion = inclusion;
         emit inclusionChanged(inclusion);
-    }
+}
+
+void QGCFenceCircle::setFenceAction (int fenceAction)
+{
+    _fenceAction = fenceAction;
 }

--- a/src/MissionManager/QGCFenceCircle.cc
+++ b/src/MissionManager/QGCFenceCircle.cc
@@ -74,8 +74,8 @@ bool QGCFenceCircle::loadFromJson(const QJsonObject& json, QString& errorString)
     QList<JsonHelper::KeyValidateInfo> keyInfoList = {
         { JsonHelper::jsonVersionKey,   QJsonValue::Double, true },
         { _jsonInclusionKey,            QJsonValue::Bool,   true },
-        { _jsonFenceActionKey,          QJsonValue::Double, true },
-        { _jsonMaxAltitudeKey,          QJsonValue::Double, true },
+        { _jsonFenceActionKey,          QJsonValue::Double, false },
+        { _jsonMaxAltitudeKey,          QJsonValue::Double, false },
     };
     if (!JsonHelper::validateKeys(json, keyInfoList, errorString)) {
         return false;

--- a/src/MissionManager/QGCFenceCircle.h
+++ b/src/MissionManager/QGCFenceCircle.h
@@ -51,7 +51,7 @@ private slots:
     void _setDirty(void);
 
 private:
-    constexpr static int DEFAULT_FENCE_ACTION = 2; // HOLD
+    constexpr static int DEFAULT_FENCE_ACTION = 0; // 0 - Use the value from the parameter
     constexpr static int DEFAULT_MAX_ALTITUDE = 0; // 0 - Disabled
 
     void _init(void);

--- a/src/MissionManager/QGCFenceCircle.h
+++ b/src/MissionManager/QGCFenceCircle.h
@@ -38,7 +38,9 @@ public:
     // Property methods
 
     bool inclusion      (void) const { return _inclusion; }
+    int  fenceAction    (void) const { return _fenceAction; }
     void setInclusion   (bool inclusion);
+    void setFenceAction (int fenceAction);
 
 signals:
     void inclusionChanged(bool inclusion);
@@ -47,11 +49,14 @@ private slots:
     void _setDirty(void);
 
 private:
+    constexpr static int DEFAULT_FENCE_ACTION = 2; // HOLD
     void _init(void);
 
     bool _inclusion;
+    int _fenceAction{DEFAULT_FENCE_ACTION};
 
     static const int _jsonCurrentVersion = 1;
 
     static const char* _jsonInclusionKey;
+    static const char* _jsonFenceActionKey;
 };

--- a/src/MissionManager/QGCFenceCircle.h
+++ b/src/MissionManager/QGCFenceCircle.h
@@ -39,8 +39,10 @@ public:
 
     bool inclusion      (void) const { return _inclusion; }
     int  fenceAction    (void) const { return _fenceAction; }
+    int  maxAltitude    (void) const { return _maxAltitude; }
     void setInclusion   (bool inclusion);
     void setFenceAction (int fenceAction);
+    void setMaxAltitude (int maxAltitude);
 
 signals:
     void inclusionChanged(bool inclusion);
@@ -50,13 +52,17 @@ private slots:
 
 private:
     constexpr static int DEFAULT_FENCE_ACTION = 2; // HOLD
+    constexpr static int DEFAULT_MAX_ALTITUDE = 0; // 0 - Disabled
+
     void _init(void);
 
     bool _inclusion;
     int _fenceAction{DEFAULT_FENCE_ACTION};
+    int _maxAltitude{DEFAULT_MAX_ALTITUDE};
 
     static const int _jsonCurrentVersion = 1;
 
     static const char* _jsonInclusionKey;
     static const char* _jsonFenceActionKey;
+    static const char* _jsonMaxAltitudeKey;
 };

--- a/src/MissionManager/QGCFencePolygon.cc
+++ b/src/MissionManager/QGCFencePolygon.cc
@@ -11,6 +11,7 @@
 #include "JsonHelper.h"
 
 const char* QGCFencePolygon::_jsonInclusionKey = "inclusion";
+const char* QGCFencePolygon::_jsonFenceActionKey = "fenceAction";
 
 QGCFencePolygon::QGCFencePolygon(bool inclusion, QObject* parent)
     : QGCMapPolygon (parent)
@@ -22,6 +23,7 @@ QGCFencePolygon::QGCFencePolygon(bool inclusion, QObject* parent)
 QGCFencePolygon::QGCFencePolygon(const QGCFencePolygon& other, QObject* parent)
     : QGCMapPolygon (other, parent)
     , _inclusion    (other._inclusion)
+    , _fenceAction  (other._fenceAction)
 {
     _init();
 }
@@ -36,6 +38,7 @@ const QGCFencePolygon& QGCFencePolygon::operator=(const QGCFencePolygon& other)
     QGCMapPolygon::operator=(other);
 
     setInclusion(other._inclusion);
+    setFenceAction(other._fenceAction);
 
     return *this;
 }
@@ -49,6 +52,7 @@ void QGCFencePolygon::saveToJson(QJsonObject& json)
 {
     json[JsonHelper::jsonVersionKey] = _jsonCurrentVersion;
     json[_jsonInclusionKey] = _inclusion;
+    json[_jsonFenceActionKey] = _fenceAction;
     QGCMapPolygon::saveToJson(json);
 }
 
@@ -59,6 +63,7 @@ bool QGCFencePolygon::loadFromJson(const QJsonObject& json, bool required, QStri
     QList<JsonHelper::KeyValidateInfo> keyInfoList = {
         { JsonHelper::jsonVersionKey,   QJsonValue::Double, true },
         { _jsonInclusionKey,            QJsonValue::Bool,   true },
+        { _jsonFenceActionKey,          QJsonValue::Double, true },
     };
     if (!JsonHelper::validateKeys(json, keyInfoList, errorString)) {
         return false;
@@ -73,6 +78,7 @@ bool QGCFencePolygon::loadFromJson(const QJsonObject& json, bool required, QStri
         return false;
     }
 
+    setFenceAction(json[_jsonFenceActionKey].toInt());
     setInclusion(json[_jsonInclusionKey].toBool());
 
     return true;
@@ -80,8 +86,12 @@ bool QGCFencePolygon::loadFromJson(const QJsonObject& json, bool required, QStri
 
 void QGCFencePolygon::setInclusion(bool inclusion)
 {
-    if (inclusion != _inclusion) {
-        _inclusion = inclusion;
-        emit inclusionChanged(inclusion);
-    }
+    _inclusion = inclusion;
+    emit inclusionChanged(inclusion);
 }
+
+void QGCFencePolygon::setFenceAction (int fenceAction)
+{
+    _fenceAction = fenceAction;
+}
+

--- a/src/MissionManager/QGCFencePolygon.cc
+++ b/src/MissionManager/QGCFencePolygon.cc
@@ -12,6 +12,7 @@
 
 const char* QGCFencePolygon::_jsonInclusionKey = "inclusion";
 const char* QGCFencePolygon::_jsonFenceActionKey = "fenceAction";
+const char* QGCFencePolygon::_jsonMaxAltitudeKey = "maxAltitude";
 
 QGCFencePolygon::QGCFencePolygon(bool inclusion, QObject* parent)
     : QGCMapPolygon (parent)
@@ -24,6 +25,7 @@ QGCFencePolygon::QGCFencePolygon(const QGCFencePolygon& other, QObject* parent)
     : QGCMapPolygon (other, parent)
     , _inclusion    (other._inclusion)
     , _fenceAction  (other._fenceAction)
+    , _maxAltitude  (other._maxAltitude)
 {
     _init();
 }
@@ -39,6 +41,7 @@ const QGCFencePolygon& QGCFencePolygon::operator=(const QGCFencePolygon& other)
 
     setInclusion(other._inclusion);
     setFenceAction(other._fenceAction);
+    setMaxAltitude(other._maxAltitude);
 
     return *this;
 }
@@ -53,6 +56,7 @@ void QGCFencePolygon::saveToJson(QJsonObject& json)
     json[JsonHelper::jsonVersionKey] = _jsonCurrentVersion;
     json[_jsonInclusionKey] = _inclusion;
     json[_jsonFenceActionKey] = _fenceAction;
+    json[_jsonMaxAltitudeKey] = _maxAltitude;
     QGCMapPolygon::saveToJson(json);
 }
 
@@ -64,6 +68,7 @@ bool QGCFencePolygon::loadFromJson(const QJsonObject& json, bool required, QStri
         { JsonHelper::jsonVersionKey,   QJsonValue::Double, true },
         { _jsonInclusionKey,            QJsonValue::Bool,   true },
         { _jsonFenceActionKey,          QJsonValue::Double, true },
+        { _jsonMaxAltitudeKey,          QJsonValue::Double, true },
     };
     if (!JsonHelper::validateKeys(json, keyInfoList, errorString)) {
         return false;
@@ -78,6 +83,7 @@ bool QGCFencePolygon::loadFromJson(const QJsonObject& json, bool required, QStri
         return false;
     }
 
+    setMaxAltitude(json[_jsonMaxAltitudeKey].toInt());
     setFenceAction(json[_jsonFenceActionKey].toInt());
     setInclusion(json[_jsonInclusionKey].toBool());
 
@@ -95,3 +101,7 @@ void QGCFencePolygon::setFenceAction (int fenceAction)
     _fenceAction = fenceAction;
 }
 
+void QGCFencePolygon::setMaxAltitude (int maxAltitude)
+{
+    _maxAltitude = maxAltitude;
+}

--- a/src/MissionManager/QGCFencePolygon.cc
+++ b/src/MissionManager/QGCFencePolygon.cc
@@ -67,8 +67,8 @@ bool QGCFencePolygon::loadFromJson(const QJsonObject& json, bool required, QStri
     QList<JsonHelper::KeyValidateInfo> keyInfoList = {
         { JsonHelper::jsonVersionKey,   QJsonValue::Double, true },
         { _jsonInclusionKey,            QJsonValue::Bool,   true },
-        { _jsonFenceActionKey,          QJsonValue::Double, true },
-        { _jsonMaxAltitudeKey,          QJsonValue::Double, true },
+        { _jsonFenceActionKey,          QJsonValue::Double, false },
+        { _jsonMaxAltitudeKey,          QJsonValue::Double, false },
     };
     if (!JsonHelper::validateKeys(json, keyInfoList, errorString)) {
         return false;

--- a/src/MissionManager/QGCFencePolygon.h
+++ b/src/MissionManager/QGCFencePolygon.h
@@ -39,8 +39,10 @@ public:
 
     bool inclusion      (void) const { return _inclusion; }
     int  fenceAction    (void) const { return _fenceAction; }
+    int  maxAltitude    (void) const { return _maxAltitude; }
     void setInclusion   (bool inclusion);
     void setFenceAction (int fenceAction);
+    void setMaxAltitude(int maxAltitude);
 
 signals:
     void inclusionChanged   (bool inclusion);
@@ -51,13 +53,17 @@ private slots:
 private:
 
     constexpr static int DEFAULT_FENCE_ACTION = 2; // HOLD
+    constexpr static int DEFAULT_MAX_ALTITUDE = 0; // 0 - Disabled
+
     void _init(void);
 
     bool _inclusion;
     int _fenceAction{DEFAULT_FENCE_ACTION};
+    int _maxAltitude{DEFAULT_MAX_ALTITUDE};
 
     static const int _jsonCurrentVersion = 1;
 
     static const char* _jsonInclusionKey;
     static const char* _jsonFenceActionKey;
+    static const char* _jsonMaxAltitudeKey;
 };

--- a/src/MissionManager/QGCFencePolygon.h
+++ b/src/MissionManager/QGCFencePolygon.h
@@ -38,7 +38,9 @@ public:
     // Property methods
 
     bool inclusion      (void) const { return _inclusion; }
+    int  fenceAction    (void) const { return _fenceAction; }
     void setInclusion   (bool inclusion);
+    void setFenceAction (int fenceAction);
 
 signals:
     void inclusionChanged   (bool inclusion);
@@ -47,11 +49,15 @@ private slots:
     void _setDirty(void);
 
 private:
+
+    constexpr static int DEFAULT_FENCE_ACTION = 2; // HOLD
     void _init(void);
 
     bool _inclusion;
+    int _fenceAction{DEFAULT_FENCE_ACTION};
 
     static const int _jsonCurrentVersion = 1;
 
     static const char* _jsonInclusionKey;
+    static const char* _jsonFenceActionKey;
 };

--- a/src/MissionManager/QGCFencePolygon.h
+++ b/src/MissionManager/QGCFencePolygon.h
@@ -52,7 +52,7 @@ private slots:
 
 private:
 
-    constexpr static int DEFAULT_FENCE_ACTION = 2; // HOLD
+    constexpr static int DEFAULT_FENCE_ACTION = 0; // 0 - Use the value from the parameter
     constexpr static int DEFAULT_MAX_ALTITUDE = 0; // 0 - Disabled
 
     void _init(void);

--- a/src/PlanView/GeoFenceEditor.qml
+++ b/src/PlanView/GeoFenceEditor.qml
@@ -154,7 +154,7 @@ QGCFlickable {
 
                     GridLayout {
                         Layout.fillWidth:   true
-                        columns:            3
+                        columns:            4
                         flow:               GridLayout.TopToBottom
                         visible:            polygonSection.checked && myGeoFenceController.polygons.count > 0
 
@@ -199,8 +199,40 @@ QGCFlickable {
                         }
 
                         QGCLabel {
-                            text:               qsTr("Delete")
+                            text:               qsTr("Action")
                             Layout.column:      2
+                            Layout.alignment:   Qt.AlignHCenter
+                        }
+
+                        Repeater {
+                            model: myGeoFenceController.polygons
+
+                            QGCComboBox {
+                                required property int index
+
+                                id : comboBoxPolygons
+                                currentIndex : comboBoxPolygons.index != -1 ? myGeoFenceController.getPolygonFenceAction(comboBoxPolygons.index) : 0
+                                textRole: "text"
+                                Layout.alignment:   Qt.AlignHCenter
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 3)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 3)
+
+                                model: [
+                                    { text: myGeoFenceController.NONE },
+                                    { text: myGeoFenceController.WARN },
+                                    { text: myGeoFenceController.HOLD },
+                                    { text: myGeoFenceController.RTL },
+                                    { text: myGeoFenceController.LAND },
+                                    { text: myGeoFenceController.TERMINATE }
+                                ]
+
+                                onActivated: myGeoFenceController.setPolygonFenceAction(comboBoxPolygons.index, currentIndex)
+                            }
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Delete")
+                            Layout.column:      3
                             Layout.alignment:   Qt.AlignHCenter
                         }
 
@@ -210,6 +242,8 @@ QGCFlickable {
                             QGCButton {
                                 text:               qsTr("Del")
                                 Layout.alignment:   Qt.AlignHCenter
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
                                 onClicked:          myGeoFenceController.deletePolygon(index)
                             }
                         }
@@ -230,7 +264,7 @@ QGCFlickable {
                     GridLayout {
                         anchors.left:       parent.left
                         anchors.right:      parent.right
-                        columns:            4
+                        columns:            5
                         flow:               GridLayout.TopToBottom
                         visible:            polygonSection.checked && myGeoFenceController.circles.count > 0
 
@@ -285,14 +319,47 @@ QGCFlickable {
 
                             FactTextField {
                                 fact:               object.radius
-                                Layout.fillWidth:   true
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
                                 Layout.alignment:   Qt.AlignHCenter
                             }
                         }
 
                         QGCLabel {
-                            text:               qsTr("Delete")
+                            text:               qsTr("Action")
                             Layout.column:      3
+                            Layout.alignment:   Qt.AlignHCenter
+                        }
+
+                        Repeater {
+                            model: myGeoFenceController.circles
+
+                            QGCComboBox {
+                                required property int index
+
+                                id : comboBoxCircles
+                                currentIndex : comboBoxCircles.index != -1 ? myGeoFenceController.getCircleFenceAction(comboBoxCircles.index) : 0
+                                textRole: "text"
+                                Layout.alignment:   Qt.AlignHCenter
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
+
+                                model: [
+                                    { text: myGeoFenceController.NONE },
+                                    { text: myGeoFenceController.WARN },
+                                    { text: myGeoFenceController.HOLD },
+                                    { text: myGeoFenceController.RTL },
+                                    { text: myGeoFenceController.LAND },
+                                    { text: myGeoFenceController.TERMINATE }
+                                ]
+
+                                onActivated: myGeoFenceController.setCircleFenceAction(comboBoxCircles.index, currentIndex)
+                            }
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Delete")
+                            Layout.column:      4
                             Layout.alignment:   Qt.AlignHCenter
                         }
 

--- a/src/PlanView/GeoFenceEditor.qml
+++ b/src/PlanView/GeoFenceEditor.qml
@@ -154,7 +154,7 @@ QGCFlickable {
 
                     GridLayout {
                         Layout.fillWidth:   true
-                        columns:            4
+                        columns:            5
                         flow:               GridLayout.TopToBottom
                         visible:            polygonSection.checked && myGeoFenceController.polygons.count > 0
 
@@ -199,8 +199,35 @@ QGCFlickable {
                         }
 
                         QGCLabel {
-                            text:               qsTr("Action")
+                            text:               qsTr("Altitude")
                             Layout.column:      2
+                            Layout.alignment:   Qt.AlignHCenter
+                        }
+
+                        Repeater {
+                            model: myGeoFenceController.polygons
+
+                            QGCTextField {
+                                required property int index
+
+                                id : textFieldPolygons
+                                property int _value: textFieldPolygons.index != -1 ? myGeoFenceController.getPolygonMaxAltitude(textFieldPolygons.index) : 0
+                                text: _value
+                                unitsLabel: "m"
+                                showUnits: true
+                                validator: IntValidator {bottom: 0; top: 100000}
+
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.alignment:   Qt.AlignHCenter
+
+                                onEditingFinished: myGeoFenceController.setPolygonMaxAltitude(textFieldPolygons.index, parseInt(textFieldPolygons.text))
+                            }
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Action")
+                            Layout.column:      3
                             Layout.alignment:   Qt.AlignHCenter
                         }
 
@@ -214,8 +241,8 @@ QGCFlickable {
                                 currentIndex : comboBoxPolygons.index != -1 ? myGeoFenceController.getPolygonFenceAction(comboBoxPolygons.index) : 0
                                 textRole: "text"
                                 Layout.alignment:   Qt.AlignHCenter
-                                Layout.maximumWidth: (geoFenceEditorRect.width / 3)
-                                Layout.minimumWidth: (geoFenceEditorRect.width / 3)
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
 
                                 model: [
                                     { text: myGeoFenceController.NONE },
@@ -232,7 +259,7 @@ QGCFlickable {
 
                         QGCLabel {
                             text:               qsTr("Delete")
-                            Layout.column:      3
+                            Layout.column:      4
                             Layout.alignment:   Qt.AlignHCenter
                         }
 
@@ -242,8 +269,8 @@ QGCFlickable {
                             QGCButton {
                                 text:               qsTr("Del")
                                 Layout.alignment:   Qt.AlignHCenter
-                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
-                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 5)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 5)
                                 onClicked:          myGeoFenceController.deletePolygon(index)
                             }
                         }
@@ -264,7 +291,7 @@ QGCFlickable {
                     GridLayout {
                         anchors.left:       parent.left
                         anchors.right:      parent.right
-                        columns:            5
+                        columns:            6
                         flow:               GridLayout.TopToBottom
                         visible:            polygonSection.checked && myGeoFenceController.circles.count > 0
 
@@ -319,15 +346,42 @@ QGCFlickable {
 
                             FactTextField {
                                 fact:               object.radius
-                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
-                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 5)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 5)
                                 Layout.alignment:   Qt.AlignHCenter
                             }
                         }
 
                         QGCLabel {
-                            text:               qsTr("Action")
+                            text:               qsTr("Altitude")
                             Layout.column:      3
+                            Layout.alignment:   Qt.AlignHCenter
+                        }
+
+                        Repeater {
+                            model: myGeoFenceController.circles
+
+                            QGCTextField {
+                                required property int index
+
+                                id : textFieldCircles
+                                property int _value: textFieldCircles.index != -1 ? myGeoFenceController.getCircleMaxAltitude(textFieldCircles.index) : 0
+                                text: _value
+                                unitsLabel: "m"
+                                showUnits: true
+                                validator: IntValidator {bottom: 0; top: 100000}
+
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 5)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 5)
+                                Layout.alignment:   Qt.AlignHCenter
+
+                                onEditingFinished: myGeoFenceController.setCircleMaxAltitude(textFieldCircles.index, parseInt(textFieldCircles.text))
+                            }
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Action")
+                            Layout.column:      4
                             Layout.alignment:   Qt.AlignHCenter
                         }
 
@@ -341,8 +395,8 @@ QGCFlickable {
                                 currentIndex : comboBoxCircles.index != -1 ? myGeoFenceController.getCircleFenceAction(comboBoxCircles.index) : 0
                                 textRole: "text"
                                 Layout.alignment:   Qt.AlignHCenter
-                                Layout.maximumWidth: (geoFenceEditorRect.width / 4)
-                                Layout.minimumWidth: (geoFenceEditorRect.width / 4)
+                                Layout.maximumWidth: (geoFenceEditorRect.width / 5)
+                                Layout.minimumWidth: (geoFenceEditorRect.width / 5)
 
                                 model: [
                                     { text: myGeoFenceController.NONE },
@@ -359,7 +413,7 @@ QGCFlickable {
 
                         QGCLabel {
                             text:               qsTr("Delete")
-                            Layout.column:      4
+                            Layout.column:      5
                             Layout.alignment:   Qt.AlignHCenter
                         }
 

--- a/src/PlanView/GeoFenceEditor.qml
+++ b/src/PlanView/GeoFenceEditor.qml
@@ -245,6 +245,7 @@ QGCFlickable {
                                 Layout.minimumWidth: (geoFenceEditorRect.width / 4)
 
                                 model: [
+                                    { text: myGeoFenceController.DEFAULT },
                                     { text: myGeoFenceController.NONE },
                                     { text: myGeoFenceController.WARN },
                                     { text: myGeoFenceController.HOLD },
@@ -399,6 +400,7 @@ QGCFlickable {
                                 Layout.minimumWidth: (geoFenceEditorRect.width / 5)
 
                                 model: [
+                                    { text: myGeoFenceController.DEFAULT },
                                     { text: myGeoFenceController.NONE },
                                     { text: myGeoFenceController.WARN },
                                     { text: myGeoFenceController.HOLD },

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -36,7 +36,7 @@ Item {
     readonly property real  _margin:                    ScreenTools.defaultFontPixelHeight * 0.5
     readonly property real  _toolsMargin:               ScreenTools.defaultFontPixelWidth * 0.75
     readonly property real  _radius:                    ScreenTools.defaultFontPixelWidth  * 0.5
-    readonly property real  _rightPanelWidth:           Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 30)
+    readonly property real  _rightPanelWidth:           Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 46)
     readonly property real  _validationPanelMinWidth:   _rightPanelWidth
     readonly property real  _validationPanelMaxWidth:   2 * parent.width / 3
     readonly property var   _defaultVehicleCoordinate:  QtPositioning.coordinate(37.803784, -122.462276)

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -36,7 +36,7 @@ Item {
     readonly property real  _margin:                    ScreenTools.defaultFontPixelHeight * 0.5
     readonly property real  _toolsMargin:               ScreenTools.defaultFontPixelWidth * 0.75
     readonly property real  _radius:                    ScreenTools.defaultFontPixelWidth  * 0.5
-    readonly property real  _rightPanelWidth:           Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 46)
+    readonly property real  _rightPanelWidth:           Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 56)
     readonly property real  _validationPanelMinWidth:   _rightPanelWidth
     readonly property real  _validationPanelMaxWidth:   2 * parent.width / 3
     readonly property var   _defaultVehicleCoordinate:  QtPositioning.coordinate(37.803784, -122.462276)


### PR DESCRIPTION
This PR brings a new feature where each geofence has its own fence action and maximum allowed altitude. 

An example is shown in the image with 3 polygon fences, where the first will send a warning, the second will make the vehicle to RTL, and the third in case all fences are breached will terminate the vehicle. 
There are also 2 exclusion fences with their own actions, in case of vehicle breaches it will activate hold action.
 
![image](https://github.com/mavlink/qgroundcontrol/assets/10188706/9ed5270f-26cd-4395-93ed-f98782f6dd5f)

Implementation is done by using `param3`  for action and `param7` for altitude when mavlink messages `MAV_CMD_NAV_FENCE_*` are sent with geofence data.

This PR also implemented capabilities that new features can be stored and loaded from the **.plan file**. 

To be able to use this with PX4 changes at PX4 also need to be applied.  https://github.com/aviant-tech/PX4-Autopilot/pull/39