### PR TITLE
Only calculate proximity sensor octagon when sensor is visible

### DIFF
--- a/src/FlightMap/MapItems/ProximityRadarMapView.qml
+++ b/src/FlightMap/MapItems/ProximityRadarMapView.qml
@@ -31,7 +31,7 @@ MapPolyline {
     line.color: Qt.rgba(1,1,1,1)
     opacity:    0.5
 
-    path: coordinate.isValid ? generateOctagon(coordinate, proximityValues) : []
+    path: enabled && proximityValues.telemetryAvailable && coordinate.isValid ? generateOctagon(coordinate, proximityValues) : []
 
     function generateOctagon(coord, sensor) {
         let path = [];


### PR DESCRIPTION
This fixes error message spam when proximity sensor is not available, as
the octagon is no longer calculated for invalid sensor data. It also
removes the need to calculate the octagon at all, if it is not visible.

Based #24 (depends on it to build)
