### PR TITLE
Remove android sdks newer than 33

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -63,10 +63,12 @@ jobs:
           ndk-version: r21e
           add-to-path: false
 
-      - name: Remove Android SDK android-33-ext
+      - name: Remove Android SDKs to force usage of android-33 only
         run: |
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext5"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext8"
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir


### PR DESCRIPTION
This will force gradle to use sdsk 33 only

Related issue as #14, picked from upstream.