### PR TITLE
Add support for rally point types

### DIFF
--- a/src/JsonHelper.h
+++ b/src/JsonHelper.h
@@ -112,6 +112,13 @@ public:
                                   bool                  writeAltitude,  ///< true: write altitude to json
                                   QJsonValue&           jsonValue);     ///< json value to save to
 
+    /// Saves a QGeoCoordinate, including type as integer
+    ///     Stored as array [ lat, lon, alt, type ]
+    static void saveGeoCoordinate(const QGeoCoordinate& coordinate,     ///< QGeoCoordinate to save
+                                  bool                  writeAltitude,  ///< true: write altitude to json
+                                  int                   type,           ///< type value to include in array
+                                  QJsonValue&           jsonValue);     ///< json value to save to
+
     /// Loads a QGeoCoordinate
     ///     Stored as array [ lon, lat, alt ]
     /// @return false: validation failed
@@ -142,6 +149,13 @@ public:
                                        bool                     altitudeRequired,   ///< true: altitude field must be specified
                                        QList<QGeoCoordinate>&   rgPoints,           ///< returned points
                                        QString&                 errorString);       ///< returned error string if load failure
+    
+    /// Load a list of QGeoCoordinates from a json array, including type
+    static bool loadGeoCoordinateArray(const QJsonValue&        jsonValue,          ///< json value which contains points
+                                       bool                     altitudeRequired,   ///< true: altitude field must be specified
+                                       QList<QGeoCoordinate>&   rgPoints,           ///< returned points
+                                       QList<int>*              types,              ///< read type to this list, unless NULL
+                                       QString&                 errorString);       ///< returned error string if load failure
 
     /// Saves a list of QGeoCoordinates to a json array
     static void saveGeoCoordinateArray(const QVariantList&  rgVarPoints,            ///< points to save
@@ -168,10 +182,12 @@ private:
     static bool _loadGeoCoordinate(const QJsonValue&    jsonValue,
                                    bool                 altitudeRequired,
                                    QGeoCoordinate&      coordinate,
+                                   int*                 type,
                                    QString&             errorString,
                                    bool                 geoJsonFormat);
     static void _saveGeoCoordinate(const QGeoCoordinate&    coordinate,
                                    bool                     writeAltitude,
+                                   int*                     type,
                                    QJsonValue&              jsonValue,
                                    bool                     geoJsonFormat);
     static QStringList _addDefaultLocKeys(QJsonObject& jsonObject);

--- a/src/MissionManager/RallyPoint.FactMetaData.json
+++ b/src/MissionManager/RallyPoint.FactMetaData.json
@@ -22,6 +22,14 @@
     "decimalPlaces":    2,
     "units":            "m",
     "default":     0.0
+},
+{
+    "name":             "Active",
+    "shortDesc": "Specify in what modes of flight the rally point is valid",
+    "type":             "uint32",
+    "enumStrings":      "Always,MR only,FW only",
+    "enumValues":       "0,1,2",
+    "default":     0
 }
 ]
 }

--- a/src/MissionManager/RallyPoint.cc
+++ b/src/MissionManager/RallyPoint.cc
@@ -16,17 +16,20 @@
 const char* RallyPoint::_longitudeFactName =    "Longitude";
 const char* RallyPoint::_latitudeFactName =     "Latitude";
 const char* RallyPoint::_altitudeFactName =     "ABSOLUTE ALTITUDE";
+const char* RallyPoint::_typeFactName =         "Active";
 
 QMap<QString, FactMetaData*> RallyPoint::_metaDataMap;
 
-RallyPoint::RallyPoint(const QGeoCoordinate& coordinate, QObject* parent)
+RallyPoint::RallyPoint(const QGeoCoordinate& coordinate, int type, QObject* parent)
     : QObject(parent)
     , _dirty(false)
     , _longitudeFact(0, _longitudeFactName, FactMetaData::valueTypeDouble)
     , _latitudeFact(0, _latitudeFactName, FactMetaData::valueTypeDouble)
     , _altitudeFact(0, _altitudeFactName, FactMetaData::valueTypeDouble)
+    , _typeFact(0, _typeFactName, FactMetaData::valueTypeUint32)
 {
     setCoordinate(coordinate);
+    setType(type);
 
     _factSetup();
 }
@@ -37,10 +40,12 @@ RallyPoint::RallyPoint(const RallyPoint& other, QObject* parent)
     , _longitudeFact(0, _longitudeFactName, FactMetaData::valueTypeDouble)
     , _latitudeFact(0, _latitudeFactName, FactMetaData::valueTypeDouble)
     , _altitudeFact(0, _altitudeFactName, FactMetaData::valueTypeDouble)
+    , _typeFact(0, _typeFactName, FactMetaData::valueTypeUint32)
 {
     _longitudeFact.setRawValue(other._longitudeFact.rawValue());
     _latitudeFact.setRawValue(other._latitudeFact.rawValue());
     _altitudeFact.setRawValue(other._altitudeFact.rawValue());
+    _typeFact.setRawValue(other._typeFact.rawValue());
 
     _factSetup();
 }
@@ -50,6 +55,7 @@ const RallyPoint& RallyPoint::operator=(const RallyPoint& other)
     _longitudeFact.setRawValue(other._longitudeFact.rawValue());
     _latitudeFact.setRawValue(other._latitudeFact.rawValue());
     _altitudeFact.setRawValue(other._altitudeFact.rawValue());
+    _typeFact.setRawValue(other._typeFact.rawValue());
 
     emit coordinateChanged(coordinate());
 
@@ -68,10 +74,12 @@ void RallyPoint::_factSetup(void)
     _longitudeFact.setMetaData(_metaDataMap[_longitudeFactName]);
     _latitudeFact.setMetaData(_metaDataMap[_latitudeFactName]);
     _altitudeFact.setMetaData(_metaDataMap[_altitudeFactName]);
+    _typeFact.setMetaData(_metaDataMap[_typeFactName]);
 
     _textFieldFacts.append(QVariant::fromValue(&_longitudeFact));
     _textFieldFacts.append(QVariant::fromValue(&_latitudeFact));
     _textFieldFacts.append(QVariant::fromValue(&_altitudeFact));
+    _textFieldFacts.append(QVariant::fromValue(&_typeFact));
 
     connect(&_longitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
     connect(&_latitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
@@ -120,4 +128,17 @@ QGeoCoordinate RallyPoint::coordinate(void) const
 void RallyPoint::_sendCoordinateChanged(void)
 {
     emit coordinateChanged(coordinate());
+}
+
+int RallyPoint::type(void) const
+{
+    return _typeFact.rawValue().toInt();
+}
+
+void RallyPoint::setType(int type)
+{
+    if (type != this->type()) {
+        _typeFact.setRawValue(type);
+        emit typeChanged(type);
+    }
 }

--- a/src/MissionManager/RallyPoint.h
+++ b/src/MissionManager/RallyPoint.h
@@ -22,7 +22,9 @@ class RallyPoint : public QObject
     Q_OBJECT
     
 public:
-    RallyPoint(const QGeoCoordinate& coordinate, QObject* parent = nullptr);
+    RallyPoint(const QGeoCoordinate& coordinate, int type, QObject* parent = nullptr);
+    RallyPoint(const QGeoCoordinate& coordinate, QObject* parent = nullptr)
+        : RallyPoint(coordinate, 0, parent) {}
     RallyPoint(const RallyPoint& other, QObject* parent = nullptr);
 
     ~RallyPoint();
@@ -30,11 +32,15 @@ public:
     const RallyPoint& operator=(const RallyPoint& other);
     
     Q_PROPERTY(QGeoCoordinate   coordinate      READ coordinate     WRITE setCoordinate     NOTIFY coordinateChanged)
+    Q_PROPERTY(int              type            READ type           WRITE setType           NOTIFY typeChanged)
     Q_PROPERTY(bool             dirty           READ dirty          WRITE setDirty          NOTIFY dirtyChanged)
     Q_PROPERTY(QVariantList     textFieldFacts  MEMBER _textFieldFacts                      CONSTANT)
 
     QGeoCoordinate coordinate(void) const;
     void setCoordinate(const QGeoCoordinate& coordinate);
+
+    int type(void) const;
+    void setType(int type);
 
     bool dirty(void) const { return _dirty; }
     void setDirty(bool dirty);
@@ -43,6 +49,7 @@ public:
 
 signals:
     void coordinateChanged      (const QGeoCoordinate& coordinate);
+    void typeChanged            (int type);
     void dirtyChanged           (bool dirty);
 
 private slots:
@@ -56,6 +63,7 @@ private:
     Fact _longitudeFact;
     Fact _latitudeFact;
     Fact _altitudeFact;
+    Fact _typeFact;
 
     QVariantList _textFieldFacts;
 
@@ -64,6 +72,7 @@ private:
     static const char* _longitudeFactName;
     static const char* _latitudeFactName;
     static const char* _altitudeFactName;
+    static const char* _typeFactName;
 };
 
 #endif

--- a/src/MissionManager/RallyPointController.h
+++ b/src/MissionManager/RallyPointController.h
@@ -78,6 +78,7 @@ private:
     bool                _itemsRequested =       false;
 
     static const int    _jsonCurrentVersion = 2;
+    static const int    _jsonCurrentVersionWithRPType = 102;
     static const char*  _jsonFileTypeValue;
     static const char*  _jsonPointsKey;
 };

--- a/src/MissionManager/RallyPointManager.h
+++ b/src/MissionManager/RallyPointManager.h
@@ -14,6 +14,7 @@
 
 #include "QGCLoggingCategory.h"
 #include "PlanManager.h"
+#include "RallyPoint.h"
 
 class Vehicle;
 class PlanManager;
@@ -31,10 +32,10 @@ public:
     ~RallyPointManager();
     
     bool                    supported       (void) const;
-    void                    sendToVehicle   (const QList<QGeoCoordinate>& rgPoints);
+    void                    sendToVehicle   (const QList<const RallyPoint*>& rgPoints);
     void                    removeAll       (void);
     QString                 editorQml       (void) const                            { return QStringLiteral("qrc:/FirmwarePlugin/RallyPointEditor.qml"); }
-    QList<QGeoCoordinate>   points          (void) const                            { return _rgPoints; }
+    QList<RallyPoint>       points          (void) const                            { return _rgPoints; }
 
     /// Error codes returned in error signal
     typedef enum {
@@ -58,6 +59,6 @@ private slots:
 protected:
     void _sendError(ErrorCode_t errorCode, const QString& errorMsg);
 
-    QList<QGeoCoordinate> _rgPoints;
-    QList<QGeoCoordinate> _rgSendPoints;
+    QList<RallyPoint> _rgPoints;
+    QList<RallyPoint> _rgSendPoints;
 };

--- a/src/PlanView/RallyPointItemEditor.qml
+++ b/src/PlanView/RallyPointItemEditor.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts              1.11
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0
 import QGroundControl.Palette       1.0
 
@@ -103,19 +104,29 @@ Rectangle {
 
             Repeater {
                 model: rallyPoint ? rallyPoint.textFieldFacts : 0
-                QGCLabel {
-                    text: modelData.name + ":"
-                }
-            }
 
-            Repeater {
-                model: rallyPoint ? rallyPoint.textFieldFacts : 0
-                FactTextField {
-                    Layout.fillWidth:   true
-                    showUnits:          true
-                    fact:               modelData
-                }
-            }
+                Column {
+                    property bool showCombo: modelData.enumStrings.length > 0
+
+                    QGCLabel {
+                        text: modelData.name + ":"
+                    }
+                    FactTextField {
+                        Layout.fillWidth:   true
+                        showUnits:          true
+                        fact:               modelData
+                        visible:            !parent.showCombo
+                    }
+                    FactComboBox {
+                        Layout.fillWidth:   true
+                        indexModel:         false
+                        fact:               parent.showCombo ? modelData : _nullFact
+                        visible:            parent.showCombo
+
+                        property var _nullFact: Fact { }
+                    }
+                }  // RowLayout
+            }  // Repeater
         } // GridLayout
     } // Rectangle
 } // Rectangle


### PR DESCRIPTION
Needed for https://github.com/aviant-tech/PX4-Autopilot/pull/49

Rally points can now be always active (default/old behavior) or setup to
only be valid for either MR or FW flight.

Uses parameter 1 in the MAVLink message
(https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RALLY_POINT) to
set type, 0=Always, 1=MR only, 2=FW only.

This adds a new version number for rally points in the JSON plan file
(2->102), but old files can be opened (RP defaults to old behavior), and
if all RPs are always active, the plan will be saved on the old format
(version 2) to enable better cross compatibility for different versions
of QGC.

Also tidy up UI a bit, to better be able to show RP data:
Old:
![Screenshot from 2023-12-11 14-20-24](https://github.com/aviant-tech/qgroundcontrol/assets/108630475/552fcc67-5971-4ab8-b322-55005197aa32)
New:
![Screenshot from 2023-12-11 14-15-16](https://github.com/aviant-tech/qgroundcontrol/assets/108630475/bfea327c-eb2b-4c4b-8a55-7803e17fb82a)

