### PR TITLE
Clearly mark "FW only" rally points

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -395,7 +395,9 @@ FlightMap {
 
             sourceItem: MissionItemIndexLabel {
                 id:         itemIndexLabel
-                label:      qsTr("R", "rally point map item label")
+                // Rally point types: 0=Always, 1=MR only, 2=FW only
+                label:      object.type == 2 ? "F" : object.type == 1 ? "M" : "R"
+                important:  object.type == 2
             }
         }
     }

--- a/src/MissionManager/RallyPoint.cc
+++ b/src/MissionManager/RallyPoint.cc
@@ -84,6 +84,7 @@ void RallyPoint::_factSetup(void)
     connect(&_longitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
     connect(&_latitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
     connect(&_altitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
+    connect(&_typeFact, &Fact::valueChanged, this, &RallyPoint::_sendTypeChanged);
 }
 
 void RallyPoint::_cacheFactMetadata() {
@@ -141,4 +142,9 @@ void RallyPoint::setType(int type)
         _typeFact.setRawValue(type);
         emit typeChanged(type);
     }
+}
+
+void RallyPoint::_sendTypeChanged(void)
+{
+    emit typeChanged(type());
 }

--- a/src/MissionManager/RallyPoint.h
+++ b/src/MissionManager/RallyPoint.h
@@ -54,6 +54,7 @@ signals:
 
 private slots:
     void _sendCoordinateChanged(void);
+    void _sendTypeChanged(void);
 
 private:
     void _factSetup(void);

--- a/src/PlanView/RallyPointMapVisuals.qml
+++ b/src/PlanView/RallyPointMapVisuals.qml
@@ -69,7 +69,9 @@ Item {
 
             sourceItem: MissionItemIndexLabel {
                 id:                 itemIndexLabel
-                label:              qsTr("R", "rally point map item label")
+                // Rally point types: 0=Always, 1=MR only, 2=FW only
+                label:              rallyPointObject.type == 2 ? "F" : rallyPointObject.type == 1 ? "M" : "R"
+                important:          rallyPointObject.type == 2
                 checked:            _editingLayer == _layerRallyPoints ? rallyPointObject === myRallyPointController.currentRallyPoint : false
                 highlightSelected:  true
                 onClicked:          myRallyPointController.currentRallyPoint = rallyPointObject

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -16,6 +16,7 @@ Canvas {
     property int    index:                  0       ///< Index to show in the indicator, 0 will show single char label instead, -1 first char of label in indicator full label to the side
     property bool   checked:                false
     property bool   small:                  !checked
+    property bool   important:              false
     property bool   child:                  false
     property bool   highlightSelected:      false
     property var    color:                  checked ? "green" : (child ? qgcPal.mapIndicatorChild : qgcPal.mapIndicator)
@@ -31,7 +32,7 @@ Canvas {
     property real   _height:            showGimbalYaw ? _gimbalYawWidth : (labelControl.visible ? labelControl.height : indicator.height)
     property real   _gimbalYawRadius:   ScreenTools.defaultFontPixelHeight
     property real   _gimbalYawWidth:    _gimbalYawRadius * 2
-    property real   _smallRadiusRaw:    Math.ceil((ScreenTools.defaultFontPixelHeight * ScreenTools.smallFontPointRatio) / 2)
+    property real   _smallRadiusRaw:    Math.ceil((ScreenTools.defaultFontPixelHeight * ScreenTools.smallFontPointRatio) / 2) * (important ? 1.8 : 1)
     property real   _smallRadius:       _smallRadiusRaw + ((_smallRadiusRaw % 2 == 0) ? 1 : 0) // odd number for better centering
     property real   _normalRadiusRaw:   Math.ceil(ScreenTools.defaultFontPixelHeight * 0.66)
     property real   _normalRadius:      _normalRadiusRaw + ((_normalRadiusRaw % 2 == 0) ? 1 : 0)
@@ -109,6 +110,7 @@ Canvas {
         width:                          _indicatorRadius * 2
         height:                         width
         color:                          root.color
+        border.width:                   important ? 3 : 0
         radius:                         _indicatorRadius
 
         QGCLabel {


### PR DESCRIPTION
- **Add missing internal type signal in rally point**
- **Mark FW rally point as "important"**

![image](https://github.com/aviant-tech/qgroundcontrol/assets/108630475/ba8616c2-dfa9-4b2d-97c3-8f05feef2e5b)