### PR TITLE
Improvements/adjustments to altitude slider and step buttons

### DIFF
--- a/src/FlightDisplay/GuidedActionList.qml
+++ b/src/FlightDisplay/GuidedActionList.qml
@@ -135,6 +135,20 @@ Rectangle {
                     visible:            guidedController.showChangeAlt
                     Layout.fillHeight:  true
                     QGCButton {
+                        // Use twice the configured "up-step" for this button
+                        property real _step: _flyViewSettings.guidedStepUpAltitude.rawValue * 2
+                        text:                "Adjust "
+                                + QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_step).toFixed(1)
+                                + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString + " up"
+                        Layout.alignment:   Qt.AlignCenter
+                        Layout.fillWidth:   true
+
+                        onClicked: {
+                            _root.visible = false
+                            guidedController.confirmAction(guidedController.actionStepAlt, _step)
+                        }
+                    }
+                    QGCButton {
                         property real _step:  _flyViewSettings.guidedStepUpAltitude.rawValue
                         text:                "Adjust "
                                 + QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_step).toFixed(1)

--- a/src/FlightDisplay/GuidedAltitudeSlider.qml
+++ b/src/FlightDisplay/GuidedAltitudeSlider.qml
@@ -69,15 +69,16 @@ Rectangle {
             anchors.right:          parent.right
             wrapMode:               Text.WordWrap
             horizontalAlignment:    Text.AlignHCenter
-            text:                   _useAMSL ? qsTr("New Alt(AMSL)") : qsTr("New Alt(rel)")
+            text:                   _useAMSL ? qsTr("New Alt\nAMSL") : qsTr("New Alt\nRel Home")
             color:                  altField.color
         }
 
         QGCLabel {
             id:                         altField
             anchors.horizontalCenter:   parent.horizontalCenter
-            text:                       newAltitudeAppUnits + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
-            color:                      !isNaN(_distanceToGround) && (-altLossGain > _distanceToGround) ? qgcPal.warningText : qgcPal.text
+            horizontalAlignment:        Text.AlignHCenter
+            text:                       labelText
+            color:                      !isNaN(_distanceToGround) && ((-altLossGain > _distanceToGround) || (altLossGain > 120.0 - _distanceToGround)) ? qgcPal.warningText : qgcPal.text
 
             property real   altExp:                 Math.pow(altSlider.value, _sliderExponent)
             property real   altLossGain:            altExp * (altSlider.value > 0 ? altGainRange : altLossRange)
@@ -85,6 +86,10 @@ Rectangle {
             property real   newAltitudeAMSLMeters:  _vehicleAltitudeAMSL + altLossGain
             property string newAltitudeAppUnits:    QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(
                                                         _useAMSL ? newAltitudeAMSLMeters : newAltitudeMeters).toFixed(1)
+            // Concatenate new altitude and unit with change relative to current altitude                                            
+            property string labelText:              newAltitudeAppUnits + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+                                                        + "\n(" + (altLossGain < 0 ? "" : "+") + QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(altLossGain).toFixed(1)
+                                                        + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString + ")"
 
             function setToMinimumTakeoff() {
                 altSlider.value = Math.pow(_activeVehicle.minimumTakeoffAltitude() / altGainRange, 1.0/_sliderExponent)


### PR DESCRIPTION
Quick, minimal work version. We should improve later, but I think we should prioritize to get the basic changes into production first, and then we can do nonessential stuff like making things configurable and pretty.

- **Add a seconds altitude step up button, with twice the step of the first**
- **Show new altitude ralatve to current altitude in slider**

![image](https://github.com/aviant-tech/qgroundcontrol/assets/108630475/31165f4a-07bc-4d98-bd1d-dd10b11db33b)
![Screenshot from 2024-03-22 15-28-58](https://github.com/aviant-tech/qgroundcontrol/assets/108630475/2ca11f88-0048-4eb5-bce0-e72c17ceaa5f)
![image](https://github.com/aviant-tech/qgroundcontrol/assets/108630475/2c75355a-e721-4455-87b7-1eca88f54d54)
