### PR TITLE
build: upgrade gstreamer for android to 1.18.6

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -78,9 +78,9 @@ jobs:
       - name:               Install gstreamer
         working-directory:  ${{ github.workspace }}
         run: |
-            wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz
-            mkdir gstreamer-1.0-android-universal-1.18.5
-            tar xf gstreamer-1.0-android-universal-1.18.5.tar.xz -C gstreamer-1.0-android-universal-1.18.5
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.6/gstreamer-1.0-android-universal-1.18.6.tar.xz
+            mkdir gstreamer-1.0-android-universal-1.18.6
+            tar xf gstreamer-1.0-android-universal-1.18.6.tar.xz -C gstreamer-1.0-android-universal-1.18.6
 
       - name: Update android manifest
         if: github.ref_name != 'Stable'

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,9 @@ install:
 
   # android dependencies: qt, gstreamer, android-ndk
   - if [ "${SPEC}" = "android-clang" ]; then
-        wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz &&
-        mkdir gstreamer-1.0-android-universal-1.18.5 &&
-        tar xf gstreamer-1.0-android-universal-1.18.5.tar.xz -C gstreamer-1.0-android-universal-1.18.5 &&
+        wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.6/gstreamer-1.0-android-universal-1.18.6.tar.xz &&
+        mkdir gstreamer-1.0-android-universal-1.18.6 &&
+        tar xf gstreamer-1.0-android-universal-1.18.6.tar.xz -C gstreamer-1.0-android-universal-1.18.6 &&
         wget --quiet https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip &&
         unzip android-ndk-r20-linux-x86_64.zip > /dev/null &&
         export ANDROID_NDK_ROOT=`pwd`/android-ndk-r20 &&

--- a/deploy/docker/Dockerfile-build-android
+++ b/deploy/docker/Dockerfile-build-android
@@ -85,9 +85,9 @@ ENV ANDROID_NDK_LATEST_HOME=/opt/android/sdk/ndk/21.3.6528147/
 
 # Install gstreamer
 WORKDIR /tmp
-RUN wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz
-WORKDIR /opt/gstreamer-1.0-android-universal-1.18.5
-RUN tar xf /tmp/gstreamer-1.0-android-universal-1.18.5.tar.xz -C .
+RUN wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.6/gstreamer-1.0-android-universal-1.18.6.tar.xz
+WORKDIR /opt/gstreamer-1.0-android-universal-1.18.6
+RUN tar xf /tmp/gstreamer-1.0-android-universal-1.18.6.tar.xz -C .
 
 # Reconfigure locale
 RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
@@ -97,4 +97,4 @@ RUN useradd user --create-home --home-dir /home/user --shell /bin/bash --uid 100
 USER user
 
 WORKDIR /project/build
-CMD [ "sh", "-c", "if [ -L /project/source/gstreamer-1.0-android-universal-1.18.5 ]; then rm -f /project/source/gstreamer-1.0-android-universal-1.18.5; fi && ln -fs /opt/gstreamer-1.0-android-universal-1.18.5 /project/source/gstreamer-1.0-android-universal-1.18.5 && qmake -r /project/source/qgroundcontrol.pro -spec android-clang CONFIG+=StableBuild CONFIG+=installer ANDROID_ABIS=\"armeabi-v7a\" && make -j$(nproc) && rm -f /project/source/gstreamer-1.0-android-universal-1.18.5" ]
+CMD [ "sh", "-c", "if [ -L /project/source/gstreamer-1.0-android-universal-1.18.6 ]; then rm -f /project/source/gstreamer-1.0-android-universal-1.18.6; fi && ln -fs /opt/gstreamer-1.0-android-universal-1.18.6 /project/source/gstreamer-1.0-android-universal-1.18.6 && qmake -r /project/source/qgroundcontrol.pro -spec android-clang CONFIG+=StableBuild CONFIG+=installer ANDROID_ABIS=\"armeabi-v7a\" && make -j$(nproc) && rm -f /project/source/gstreamer-1.0-android-universal-1.18.6" ]

--- a/src/VideoReceiver/README.md
+++ b/src/VideoReceiver/README.md
@@ -89,12 +89,12 @@ The installer places them under ~/Library/Developer/GStreamer/iPhone.sdk/GStream
 
 ### Android
 
-Download the gstreamer from here: [gstreamer-1.0-android-universal-1.18.5.tar.xz](https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz)
+Download the gstreamer from here: [gstreamer-1.0-android-universal-1.18.6.tar.xz](https://gstreamer.freedesktop.org/data/pkg/android/1.18.6/gstreamer-1.0-android-universal-1.18.6.tar.xz)
 
-Create a directory named "gstreamer-1.0-android-universal-1.18.5" under the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). Extract the downloaded archive under this directory. That's where the build system will look for it. Make sure your archive tool doesn't create any additional top level directories. The structure after extracting the archive should look like this:
+Create a directory named "gstreamer-1.0-android-universal-1.18.6" under the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). Extract the downloaded archive under this directory. That's where the build system will look for it. Make sure your archive tool doesn't create any additional top level directories. The structure after extracting the archive should look like this:
 ```
 qgroundcontrol
-├── gstreamer-1.0-android-universal-1.18.5
+├── gstreamer-1.0-android-universal-1.18.6
 │   │
 │   ├──armv7
 │   │   ├── bin

--- a/src/VideoReceiver/VideoReceiver.pri
+++ b/src/VideoReceiver/VideoReceiver.pri
@@ -62,16 +62,16 @@ LinuxBuild {
         QMAKE_POST_LINK += $$escape_expand(\\n) xcopy \"$$GST_ROOT_WIN\\lib\\gstreamer-1.0\\*.dll\" \"$$DESTDIR_WIN\\gstreamer-plugins\\\" /Y $$escape_expand(\\n)
     }
 } else:AndroidBuild {
-    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-1.18.5/***
+    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-1.18.6/***
     contains(ANDROID_TARGET_ARCH, armeabi-v7a) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/armv7
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.6/armv7
     } else:contains(ANDROID_TARGET_ARCH, arm64-v8a) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/arm64
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.6/arm64
     } else:contains(ANDROID_TARGET_ARCH, x86_64) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86_64
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.6/x86_64
     } else {
         message(Unknown ANDROID_TARGET_ARCH $$ANDROID_TARGET_ARCH)
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.6/x86
     }
     exists($$GST_ROOT) {
         QMAKE_CXXFLAGS  += -pthread


### PR DESCRIPTION
From 1.18.5, since this version is no longer available from the download
site used.

For old version, all but the newest patch seems to be removed:
https://gstreamer.freedesktop.org/data/pkg/android/
