### PR TITLE
Github actions: releases built on tag push will be pre-release

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -110,4 +110,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          prerelease: true
           files: ${{ runner.temp }}/shadow_build_dir/package/${{ matrix.ARTIFACT }}

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -79,4 +79,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          prerelease: true
           files: ${{ runner.temp }}/shadow_build_dir/package/${{ env.ARTIFACT }}

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -111,4 +111,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          prerelease: true
           files: ${{ steps.corrected_path.outputs.CORRECTED_PATH }}


### PR DESCRIPTION
This is normally what we want, and we will manually update it to
"latest" when it is ready for production.
