### PR TITLE
Use drone name in QGC

### DIFF
--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -138,7 +138,7 @@ MapQuickItem {
                         }
                     }
                 } else if (_multiVehicle) {
-                    label += qsTr("Vehicle %1").arg(vehicle.id)
+                    label += vehicle.name
                 }
                 return label
             }

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -145,7 +145,7 @@ void MultiVehicleManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicle
     emit vehicleAdded(vehicle);
 
     if (_vehicles.count() > 1) {
-        qgcApp()->showAppMessage(tr("Connected to Vehicle %1").arg(vehicleId));
+        qgcApp()->showAppMessage(tr("Connected to %1").arg(vehicle->name()));
     } else {
         setActiveVehicle(vehicle);
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -512,6 +512,12 @@ Vehicle::~Vehicle()
 #endif
 }
 
+QString Vehicle::name() const
+{
+    // Deduce name from id for now, until we can receive more complex information from the vehicle
+    return QString("%1%2").arg(_id > 199 ? "TEST" : _id > 99 ? "NX" : "NT").arg(_id % 100, 2, 10, QLatin1Char('0'));
+}
+
 void Vehicle::prepareDelete()
 {
     if(_cameraManager) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -158,6 +158,7 @@ public:
     Q_ENUM(CheckList)
 
     Q_PROPERTY(int                  id                          READ id                                                             CONSTANT)
+    Q_PROPERTY(QString              name                        READ name                                                           CONSTANT)
     Q_PROPERTY(AutoPilotPlugin*     autopilot                   MEMBER _autopilotPlugin                                             CONSTANT)
     Q_PROPERTY(QGeoCoordinate       coordinate                  READ coordinate                                                     NOTIFY coordinateChanged)
     Q_PROPERTY(QGeoCoordinate       positionSetpoint            READ positionSetpoint                                               NOTIFY positionSetpointChanged)
@@ -462,6 +463,7 @@ public:
 
     // Property accesors
     int id() const{ return _id; }
+    QString name() const;
     MAV_AUTOPILOT firmwareType() const { return _firmwareType; }
     MAV_TYPE vehicleType() const { return _vehicleType; }
     QGCMAVLink::VehicleClass_t vehicleClass(void) const { return QGCMAVLink::vehicleClass(_vehicleType); }

--- a/src/ui/toolbar/MultiVehicleSelector.qml
+++ b/src/ui/toolbar/MultiVehicleSelector.qml
@@ -29,8 +29,9 @@ QGCComboBox {
     property bool showIndicator: _multipleVehicles
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
-    property bool   _multipleVehicles:  QGroundControl.multiVehicleManager.vehicles.count > 1
+    property bool   _multipleVehicles:  QGroundControl.multiVehicleManager.vehicles.count > 0
     property var    _vehicleModel:      [ ]
+    property var    _vehicleIds:        [ ]
 
     Connections {
         target:         QGroundControl.multiVehicleManager.vehicles
@@ -43,10 +44,12 @@ QGCComboBox {
     function _updateVehicleModel() {
         var newCurrentIndex = -1
         var newModel = [ ]
+        var newIds = [ ]
         if (_multipleVehicles) {
             for (var i = 0; i < QGroundControl.multiVehicleManager.vehicles.count; i++) {
                 var vehicle = QGroundControl.multiVehicleManager.vehicles.get(i)
-                newModel.push(qsTr("Vehicle") + " " + vehicle.id)
+                newModel.push(vehicle.name)
+                newIds.push(vehicle.id)
 
                 if (vehicle.id === _activeVehicle.id) {
                     newCurrentIndex = i
@@ -55,13 +58,20 @@ QGCComboBox {
         }
         currentIndex = -1
         _vehicleModel = newModel
+        _vehicleIds = newIds
         currentIndex = newCurrentIndex
     }
 
     onActivated: {
-        var vehicleId = textAt(index).split(" ")[1]
-        var vehicle = QGroundControl.multiVehicleManager.getVehicleById(vehicleId)
-        QGroundControl.multiVehicleManager.activeVehicle = vehicle
+        var vehicle = QGroundControl.multiVehicleManager.getVehicleById(_vehicleIds[index])
+        if (vehicle) {
+            // Do not attempt to set the active vehicle to null if the index for any reason
+            // was wrong (should not happen)
+            QGroundControl.multiVehicleManager.activeVehicle = vehicle
+        } else {
+            // If there for some reason is a problem with the index
+            // (should not happen), reset the model
+            _updateVehicleModel()
+        }
     }
 }
-


### PR DESCRIPTION
- **Add name to vehicles based system id**
- **Use vehicle name instead of system id for multi vehicle indications**

![image](https://github.com/aviant-tech/qgroundcontrol/assets/108630475/0da2de2c-feaf-4c70-bbd4-2d0d52bdd84f)
