### PR TITLE
Github actions: Remove android-35 from build image

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -72,6 +72,7 @@ jobs:
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext10"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext11"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext12"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-35"
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir


### PR DESCRIPTION
Github workflow image ubuntu-20.04 version 20240624 have added Android
SDK Platform android-35. Current build setup seem to not support
anything newer than 33, so remove all ext* and 34/35 versions.
