### PR TITLE
Aviant/display goto distance

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -422,7 +422,7 @@ FlightMap {
         anchorPoint.y:  sourceItem.anchorPointY
         sourceItem: MissionItemIndexLabel {
             function generateGoToText(coord) {
-                const defaultText = qsTr("Go here", "Go to location waypoint");
+                const defaultText = gotoLocationItem.inGotoFlightMode ? qsTr("Going here", "Going to location waypoint") : qsTr("Go here", "Go to location waypoint");
                 if (!coord || !_activeVehicleCoordinate) {
                     return defaultText;
                 }

--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -574,8 +574,20 @@ FlightMap {
             id: clickMenu
             property var coord
             QGCMenuItem {
-                text:           qsTr("Go to location")
-                visible:        globals.guidedControllerFlyView.showGotoLocation
+                function generateMenuItemText(coord) {
+                    const defaultText = qsTr("Go to location");
+                    if (!coord || !_activeVehicleCoordinate) {
+                        return defaultText;
+                    }
+                    let distance = _activeVehicleCoordinate.distanceTo(coord);
+                    if (distance !== undefined) {
+                        return defaultText + " (" + distance.toFixed(1) + "m)";
+                    }
+                    return defaultText;
+                }
+
+                text:    generateMenuItemText(clickMenu.coord)
+                visible: globals.guidedControllerFlyView.showGotoLocation
 
                 onTriggered: {
                     gotoLocationItem.show(clickMenu.coord)

--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -421,9 +421,21 @@ FlightMap {
         anchorPoint.x:  sourceItem.anchorPointX
         anchorPoint.y:  sourceItem.anchorPointY
         sourceItem: MissionItemIndexLabel {
+            function generateGoToText(coord) {
+                const defaultText = qsTr("Go here", "Go to location waypoint");
+                if (!coord || !_activeVehicleCoordinate) {
+                    return defaultText;
+                }
+                let distance = _activeVehicleCoordinate.distanceTo(coord);
+                if (distance !== undefined) {
+                    return defaultText + " (" + distance.toFixed(1) + "m)";
+                }
+                return defaultText;
+            }
+
             checked:    true
             index:      -1
-            label:      qsTr("Go here", "Go to location waypoint")
+            label:      generateGoToText(gotoLocationItem.coordinate)
         }
 
         property bool inGotoFlightMode: _activeVehicle ? _activeVehicle.flightMode === _activeVehicle.gotoFlightMode : false


### PR DESCRIPTION
- Show distance to the goto-point next to "Go to location"
- Show distance to goto-point next to "Go here"-container
- Allow moving the "Go here"-container to move the point you want to move to before the goto is confirmed
- Change text to "Going here" when the goto is confirmed