### PR TITLE
fix: remove warning about newer version

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -831,6 +831,7 @@ void QGCApplication::_qgcCurrentStableVersionDownloadComplete(QString /*remoteFi
 
             qDebug() << version;
 
+            /* As we handle outdated version in multi-qgc setup, we don't need to show this message
             int majorVersion, minorVersion, buildVersion;
             if (_parseVersionText(version, majorVersion, minorVersion, buildVersion)) {
                 if (_majorVersion < majorVersion ||
@@ -839,6 +840,7 @@ void QGCApplication::_qgcCurrentStableVersionDownloadComplete(QString /*remoteFi
                     showAppMessage(tr("There is a newer version of %1 available. You can download it from %2.").arg(applicationName()).arg(toolbox()->corePlugin()->stableDownloadLocation()), tr("New Version Available"));
                 }
             }
+            */
         }
     } else {
         qDebug() << "Download QGC stable version failed" << errorMsg;


### PR DESCRIPTION
As we handle this in the multi-qgc setup, this is not needed


