### PR TITLE
fix: place warning sidebar above telemetry toolbar

### DIFF
--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -153,6 +153,8 @@ Item {
         id:                     vehicleWarningSideBar
         anchors.margins:        _toolsMargin
         anchors.left:           parent.left
+        anchors.bottom:         parent.bottom
+        anchors.bottomMargin:   (_toolsMargin * 4) + telemetryPanel.valueArea.height
         minWidth:               _rightPanelWidth
         maxWidth:               _rightPanelWidth * 2  
         availableHeight:        parent.height - (toolStrip.height + ScreenTools.defaultFontPixelHeight)

--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -24,6 +24,7 @@ Rectangle {
     radius:             ScreenTools.defaultFontPixelWidth / 2
 
     property bool       bottomMode: true
+    property alias      valueArea: valueArea
 
     DeadMouseArea { anchors.fill: parent }
 

--- a/src/FlightMap/Widgets/VehicleWarningSideBar.qml
+++ b/src/FlightMap/Widgets/VehicleWarningSideBar.qml
@@ -24,11 +24,6 @@ Rectangle {
     property var _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
     property int maxHeight:             parent.height * 0.5
     property int maxWidthBasedOnWindow: parent.width * 0.25
-
-    anchors {
-        bottom:       parent.bottom
-        bottomMargin: ScreenTools.defaultFontPixelWidth
-    }
     
     height:  Math.min(Math.min(vehicleWarningSideBarLayout.implicitHeight + ScreenTools.defaultFontPixelWidth, maxHeight), availableHeight)
     width:   Math.min(Math.max(maxWidthBasedOnWindow, minWidth), maxWidth)


### PR DESCRIPTION
Currently, sidebar gets overlapped by telemetry bar on small/medium screens, see image below. By placing the sidebar on top of the valueArea of the telemetrybar we avoid this. The same happens for the winch widget, so this could be applied there as well, but when the batterywidget is introduced, the telemetry bar will take less horizontal space, so then this may be less of an issue.

New solution:
![image](https://github.com/user-attachments/assets/0afadaf4-80ed-4026-96c4-14a737e55dfc)
Old solution:
![image](https://github.com/user-attachments/assets/4ac98974-adc7-4698-8016-89e212cd68e5)
