### PR TITLE
Remove need for restart after mission upload

### DIFF
--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -105,6 +105,8 @@ Item {
     readonly property int actionStepAlt:                    25
 
     property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
+    property var    _planMasterController:      globals.planMasterControllerPlanView
+    property bool   _syncInProgress:            _planMasterController.syncInProgress
     property bool   _useChecklist:              QGroundControl.settingsManager.appSettings.useChecklist.rawValue && QGroundControl.corePlugin.options.preFlightChecklistUrl.toString().length
     property bool   _enforceChecklist:          _useChecklist && QGroundControl.settingsManager.appSettings.enforceChecklist.rawValue
     property bool   _canArm:                    canArm()
@@ -296,12 +298,22 @@ Item {
         }
     }
 
+    Connections {
+        target: _planMasterController
+        function onSyncInProgressChanged() {
+            _syncInProgress = _planMasterController.syncInProgress
+            _canArm = canArm()
+        }
+    }
+
+
+
     function planError() {
         return _activeVehicle && (_activeVehicle.missionManagerError != "" || _activeVehicle.geoFenceManagerError != "" || _activeVehicle.rallyPointManagerError != "")
     }
 
     function canArm() {
-        return _activeVehicle ? !planError() && (_useChecklist ? (_enforceChecklist ? _activeVehicle.checkListState === Vehicle.CheckListPassed : true) : true) : false
+        return _activeVehicle ? !planError() && (_useChecklist ? (_enforceChecklist ? _activeVehicle.checkListState === Vehicle.CheckListPassed : true) : true) && !_syncInProgress : false
     }
 
     function armVehicleRequest() {

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -107,7 +107,7 @@ Item {
     property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
     property bool   _useChecklist:              QGroundControl.settingsManager.appSettings.useChecklist.rawValue && QGroundControl.corePlugin.options.preFlightChecklistUrl.toString().length
     property bool   _enforceChecklist:          _useChecklist && QGroundControl.settingsManager.appSettings.enforceChecklist.rawValue
-    property bool   _canArm:                    _activeVehicle ? (_useChecklist ? (_enforceChecklist ? _activeVehicle.checkListState === Vehicle.CheckListPassed : true) : true) : false
+    property bool   _canArm:                    canArm()
 
     property bool showEmergenyStop:     _guidedActionsEnabled && !_hideEmergenyStop && _vehicleArmed && _vehicleFlying
     property bool showArm:              _guidedActionsEnabled && !_vehicleArmed && _canArm
@@ -281,6 +281,27 @@ Item {
         function onDisarmVehicleRequest() { disarmVehicleRequest() }
         function onVtolTransitionToFwdFlightRequest() { vtolTransitionToFwdFlightRequest() }
         function onVtolTransitionToMRFlightRequest() { vtolTransitionToMRFlightRequest() }
+    }
+
+    Connections {
+        target: _activeVehicle
+        function onRallyPointManagerErrorChanged() {
+            _canArm = canArm()
+        }
+        function onGeoFenceManagerErrorChanged() {
+            _canArm = canArm()
+        }
+        function onMissionManagerErrorChanged() {
+            _canArm = canArm()
+        }
+    }
+
+    function planError() {
+        return _activeVehicle && (_activeVehicle.missionManagerError != "" || _activeVehicle.geoFenceManagerError != "" || _activeVehicle.rallyPointManagerError != "")
+    }
+
+    function canArm() {
+        return _activeVehicle ? !planError() && (_useChecklist ? (_enforceChecklist ? _activeVehicle.checkListState === Vehicle.CheckListPassed : true) : true) : false
     }
 
     function armVehicleRequest() {

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -107,6 +107,7 @@ Item {
     property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
     property var    _planMasterController:      globals.planMasterControllerPlanView
     property bool   _syncInProgress:            _planMasterController.syncInProgress
+    property bool   _dirty:                     _planMasterController.dirty
     property bool   _useChecklist:              QGroundControl.settingsManager.appSettings.useChecklist.rawValue && QGroundControl.corePlugin.options.preFlightChecklistUrl.toString().length
     property bool   _enforceChecklist:          _useChecklist && QGroundControl.settingsManager.appSettings.enforceChecklist.rawValue
     property bool   _canArm:                    canArm()
@@ -304,6 +305,10 @@ Item {
             _syncInProgress = _planMasterController.syncInProgress
             _canArm = canArm()
         }
+        function onDirtyChanged() {
+            _dirty = _planMasterController.dirty
+            _canArm = canArm()
+        }
     }
 
 
@@ -313,7 +318,7 @@ Item {
     }
 
     function canArm() {
-        return _activeVehicle ? !planError() && (_useChecklist ? (_enforceChecklist ? _activeVehicle.checkListState === Vehicle.CheckListPassed : true) : true) && !_syncInProgress : false
+        return _activeVehicle ? !planError() && !_dirty && (_useChecklist ? (_enforceChecklist ? _activeVehicle.checkListState === Vehicle.CheckListPassed : true) : true) && !_syncInProgress : false
     }
 
     function armVehicleRequest() {

--- a/src/MissionManager/AviantMissionTools.cc
+++ b/src/MissionManager/AviantMissionTools.cc
@@ -368,7 +368,11 @@ void AviantMissionTools::_parseAndLoadMissionResponse(const QByteArray &bytes)
                 tr("Mission Tools - ") + _getOperationName(_currentOperation));
         return;
     }
-        
+
+    if (_currentOperation == FetchKyteOrderMissionFile) {
+        _masterController->clearCurrentPlanFile();
+    }
+
     qgcApp()->showAppMessage(tr("Operation successful"), tr("Mission Tools - ") + _getOperationName(_currentOperation));
 }
 

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -353,6 +353,7 @@ void GeoFenceController::_managerLoadComplete(void)
         emit loadComplete();
     }
     _itemsRequested = false;
+    _managerVehicle->clearGeoFenceManagerError();
 }
 
 void GeoFenceController::_managerSendComplete(bool error)

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -114,6 +114,7 @@ void GeoFenceController::_managerVehicleChanged(Vehicle* managerVehicle)
     connect(_geoFenceManager, &GeoFenceManager::sendComplete,                   this, &GeoFenceController::_managerSendComplete);
     connect(_geoFenceManager, &GeoFenceManager::removeAllComplete,              this, &GeoFenceController::_managerRemoveAllComplete);
     connect(_geoFenceManager, &GeoFenceManager::inProgressChanged,              this, &GeoFenceController::syncInProgressChanged);
+    connect(_geoFenceManager, &GeoFenceManager::progressPct,                    this, &GeoFenceController::_progressPctChanged);
 
     //-- GeoFenceController::supported() tests both the capability bit AND the protocol version.
     connect(_managerVehicle,  &Vehicle::capabilityBitsChanged,                  this, &GeoFenceController::supportedChanged);
@@ -520,6 +521,14 @@ void GeoFenceController::_parametersReady(void)
     _px4ParamCircularFenceFact = _managerVehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, _px4ParamCircularFence);
     connect(_px4ParamCircularFenceFact, &Fact::rawValueChanged, this, &GeoFenceController::paramCircularFenceChanged);
     emit paramCircularFenceChanged();
+}
+
+void GeoFenceController::_progressPctChanged(double progressPct)
+{
+    if (!QGC::fuzzyCompare(progressPct, _progressPct)) {
+        _progressPct = progressPct;
+        emit progressPctChanged(progressPct);
+    }
 }
 
 bool GeoFenceController::isEmpty(void) const

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -35,6 +35,7 @@ public:
     Q_PROPERTY(QGeoCoordinate       breachReturnPoint       READ breachReturnPoint      WRITE setBreachReturnPoint  NOTIFY breachReturnPointChanged)
     Q_PROPERTY(Fact*                breachReturnAltitude    READ breachReturnAltitude                               CONSTANT)
     Q_PROPERTY(QStringList          fenceActions            READ fenceActions                                       CONSTANT)
+    Q_PROPERTY(double               progressPct             READ progressPct                                        NOTIFY progressPctChanged)
 
     // Hack to expose PX4 circular fence controlled by GF_MAX_HOR_DIST
     Q_PROPERTY(double               paramCircularFence  READ paramCircularFence                             NOTIFY paramCircularFenceChanged)
@@ -83,14 +84,16 @@ public:
     QmlObjectListModel* circles                 (void) { return &_circles; }
     QGeoCoordinate      breachReturnPoint       (void) const { return _breachReturnPoint; }
 
-    void setBreachReturnPoint   (const QGeoCoordinate& breachReturnPoint);
-    bool isEmpty                (void) const;
+    void   setBreachReturnPoint   (const QGeoCoordinate& breachReturnPoint);
+    bool   isEmpty                (void) const;
+    double progressPct            (void) const { return _progressPct; }
 
 signals:
     void breachReturnPointChanged       (QGeoCoordinate breachReturnPoint);
     void editorQmlChanged               (QString editorQml);
     void loadComplete                   (void);
     void paramCircularFenceChanged      (void);
+    void progressPctChanged (double progressPct);
 
 private slots:
     void _polygonDirtyChanged       (bool dirty);
@@ -102,7 +105,8 @@ private slots:
     void _managerSendComplete       (bool error);
     void _managerRemoveAllComplete  (bool error);
     void _parametersReady           (void);
-    void _managerVehicleChanged      (Vehicle* managerVehicle);
+    void _managerVehicleChanged     (Vehicle* managerVehicle);
+    void _progressPctChanged        (double progressPct);
 
 private:
     void _init(void);
@@ -117,6 +121,7 @@ private:
     double              _breachReturnDefaultAltitude =  qQNaN();
     bool                _itemsRequested =               false;
     Fact*               _px4ParamCircularFenceFact =    nullptr;
+    double              _progressPct =                  0;
 
     static QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -203,7 +203,7 @@ void MissionController::_newMissionItemsAvailableFromVehicle(bool removeAllReque
 
         _visualItems = newControllerMissionItems;
         _settingsItem = settingsItem;
-
+        _managerVehicle->clearMissionManagerError();
         MissionController::_scanForAdditionalSettings(_visualItems, _masterController);
 
         _initAllVisualItems();

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -594,6 +594,7 @@ void PlanMasterController::removeAllFromVehicle(void)
         if (_rallyPointController.supported()) {
             _rallyPointController.removeAllFromVehicle();
         }
+        _currentPlanFile.clear();
         setDirty(false);
     } else {
         qWarning() << "PlanMasterController::removeAllFromVehicle called while offline";

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -437,6 +437,12 @@ void PlanMasterController::loadFromFile(const QString& filename)
     }
 }
 
+void PlanMasterController::clearCurrentPlanFile()
+{
+    _currentPlanFile.clear();
+    emit currentPlanFileChanged();
+}
+
 QJsonDocument PlanMasterController::saveToJson()
 {
     QJsonObject planJson;

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -105,6 +105,8 @@ public:
     QJsonDocument saveToJson    ();
     bool          loadFromJson  (QJsonDocument jsonDoc, QString &errorString);
 
+    void          clearCurrentPlanFile ();
+
     Vehicle* controllerVehicle(void) { return _controllerVehicle; }
     Vehicle* managerVehicle(void) { return _managerVehicle; }
 

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -247,6 +247,7 @@ void RallyPointController::_managerLoadComplete(void)
         setDirty(false);
         _setFirstPointCurrent();
         emit loadComplete();
+        _managerVehicle->clearRallyPointManagerError();
     }
     _itemsRequested = false;
 }

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -71,6 +71,7 @@ void RallyPointController::_managerVehicleChanged(Vehicle* managerVehicle)
     connect(_rallyPointManager, &RallyPointManager::sendComplete,       this, &RallyPointController::_managerSendComplete);
     connect(_rallyPointManager, &RallyPointManager::removeAllComplete,  this, &RallyPointController::_managerRemoveAllComplete);
     connect(_rallyPointManager, &RallyPointManager::inProgressChanged,  this, &RallyPointController::syncInProgressChanged);
+    connect(_rallyPointManager, &RallyPointManager::progressPct,        this, &RallyPointController::_progressPctChanged);
 
     //-- RallyPointController::supported() tests both the capability bit AND the protocol version.
     connect(_managerVehicle,    &Vehicle::capabilityBitsChanged,        this, &RallyPointController::supportedChanged);
@@ -354,6 +355,14 @@ bool RallyPointController::showPlanFromManagerVehicle (void)
             _managerLoadComplete();
             return false;
         }
+    }
+}
+
+void RallyPointController::_progressPctChanged(double progressPct)
+{
+    if (!QGC::fuzzyCompare(progressPct, _progressPct)) {
+        _progressPct = progressPct;
+        emit progressPctChanged(progressPct);
     }
 }
 

--- a/src/MissionManager/RallyPointController.h
+++ b/src/MissionManager/RallyPointController.h
@@ -32,6 +32,7 @@ public:
     Q_PROPERTY(QmlObjectListModel*  points                  READ points                                             CONSTANT)
     Q_PROPERTY(QString              editorQml               READ editorQml                                          CONSTANT)
     Q_PROPERTY(QObject*             currentRallyPoint       READ currentRallyPoint      WRITE setCurrentRallyPoint  NOTIFY currentRallyPointChanged)
+    Q_PROPERTY(double               progressPct             READ progressPct                                        NOTIFY progressPctChanged)
 
     Q_INVOKABLE void addPoint       (QGeoCoordinate point);
     Q_INVOKABLE void removePoint    (QObject* rallyPoint);
@@ -54,12 +55,14 @@ public:
     QString             editorQml               (void) const;
     QObject*            currentRallyPoint       (void) const { return _currentRallyPoint; }
 
-    void setCurrentRallyPoint   (QObject* rallyPoint);
-    bool isEmpty                (void) const;
+    void   setCurrentRallyPoint   (QObject* rallyPoint);
+    bool   isEmpty                (void) const;
+    double progressPct            (void) const { return _progressPct; }
 
 signals:
     void currentRallyPointChanged(QObject* rallyPoint);
     void loadComplete(void);
+    void progressPctChanged (double progressPct);
 
 private slots:
     void _managerLoadComplete       (void);
@@ -68,6 +71,7 @@ private slots:
     void _setFirstPointCurrent      (void);
     void _updateContainsItems       (void);
     void _managerVehicleChanged     (Vehicle* managerVehicle);
+    void _progressPctChanged        (double progressPct);
 
 private:
     Vehicle*            _managerVehicle =       nullptr;
@@ -76,6 +80,7 @@ private:
     QmlObjectListModel  _points;
     QObject*            _currentRallyPoint =    nullptr;
     bool                _itemsRequested =       false;
+    double              _progressPct =          0;
 
     static const int    _jsonCurrentVersion = 2;
     static const int    _jsonCurrentVersionWithRPType = 102;

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -125,7 +125,7 @@ Item {
         anchors.bottom:         parent.bottom
         anchors.leftMargin:     _margins
         anchors.left:           parent.left
-        columnSpacing:          0
+        columnSpacing:          _smallValueWidth
         columns:                5
 
         GridLayout {
@@ -162,7 +162,6 @@ Item {
             QGCLabel {
                 text:                   _distanceText
                 font.pointSize:         _dataFontSize
-                Layout.minimumWidth:    _largeValueWidth
             }
 
             QGCLabel { text: qsTr("Gradient:"); font.pointSize: _dataFontSize; }
@@ -207,7 +206,6 @@ Item {
             QGCLabel {
                 text:                   _missionMaxTelemetryText
                 font.pointSize:         _dataFontSize
-                Layout.minimumWidth:    _largeValueWidth
             }
 
             QGCLabel { text: qsTr("Time:"); font.pointSize: _dataFontSize; }
@@ -282,7 +280,6 @@ Item {
                     return parts.pop();
                 }
             }
-            Item { width: 1; height: 1 }
         }
     }
 

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -85,40 +85,6 @@ Item {
         return complete
     }
 
-    // Progress bar
-    Connections {
-        target: _controllerValid ? _planMasterController.missionController : null
-        onProgressPctChanged: {
-            if (_controllerProgressPct === 1) {
-                missionStats.visible = false
-                uploadCompleteText.visible = true
-                progressBar.visible = false
-                resetProgressTimer.start()
-            } else if (_controllerProgressPct > 0) {
-                progressBar.visible = true
-            }
-        }
-    }
-
-    Timer {
-        id:             resetProgressTimer
-        interval:       5000
-        onTriggered: {
-            missionStats.visible = true
-            uploadCompleteText.visible = false
-        }
-    }
-
-    QGCLabel {
-        id:                     uploadCompleteText
-        anchors.fill:           parent
-        font.pointSize:         ScreenTools.largeFontPointSize
-        horizontalAlignment:    Text.AlignHCenter
-        verticalAlignment:      Text.AlignVCenter
-        text:                   qsTr("Done")
-        visible:                false
-    }
-
     GridLayout {
         id:                     missionStats
         anchors.top:            parent.top
@@ -243,7 +209,7 @@ Item {
             id:          uploadButton
             text:        _controllerDirty ? qsTr("Upload Required") : qsTr("Upload")
             enabled:     !_controllerSyncInProgress
-            visible:     !_controllerOffline && !_controllerSyncInProgress && !uploadCompleteText.visible
+            visible:     !_controllerOffline && !_controllerSyncInProgress
             primary:     _controllerDirty
             onClicked:   _planMasterController.upload()
 
@@ -280,69 +246,6 @@ Item {
                     return parts.pop();
                 }
             }
-        }
-    }
-
-    // Small mission download progress bar
-    Rectangle {
-        id:             progressBar
-        anchors.left:   parent.left
-        anchors.bottom: parent.bottom
-        height:         4
-        width:          _controllerProgressPct * parent.width
-        color:          qgcPal.colorGreen
-        visible:        false
-
-        onVisibleChanged: {
-            if (visible) {
-                largeProgressBar._userHide = false
-            }
-        }
-    }
-
-    // Large mission download progress bar
-    Rectangle {
-        id:             largeProgressBar
-        anchors.bottom: parent.bottom
-        anchors.left:   parent.left
-        anchors.right:  parent.right
-        height:         parent.height
-        color:          qgcPal.window
-        visible:        _showLargeProgress
-
-        property bool _userHide:                false
-        property bool _showLargeProgress:       progressBar.visible && !_userHide && qgcPal.globalTheme === QGCPalette.Light
-
-        Connections {
-            target:                 QGroundControl.multiVehicleManager
-            onActiveVehicleChanged: largeProgressBar._userHide = false
-        }
-
-        Rectangle {
-            anchors.top:    parent.top
-            anchors.bottom: parent.bottom
-            width:          _controllerProgressPct * parent.width
-            color:          qgcPal.colorGreen
-        }
-
-        QGCLabel {
-            anchors.centerIn:   parent
-            text:               qsTr("Syncing Mission")
-            font.pointSize:     ScreenTools.largeFontPointSize
-        }
-
-        QGCLabel {
-            anchors.margins:    _margin
-            anchors.right:      parent.right
-            anchors.bottom:     parent.bottom
-            text:               qsTr("Click anywhere to hide")
-
-            property real _margin: ScreenTools.defaultFontPixelWidth / 2
-        }
-
-        MouseArea {
-            anchors.fill:   parent
-            onClicked:      largeProgressBar._userHide = true
         }
     }
 }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -400,12 +400,15 @@ Item {
             globals.planMasterControllerPlanView = _planMasterController
         }
 
+        /*
+        We never want to discard the mission in plan view, so we remove the popup alltogehter
         onPromptForPlanUsageOnVehicleChange: {
             if (!_promptForPlanUsageShowing) {
                 _promptForPlanUsageShowing = true
                 mainWindow.showPopupDialogFromComponent(promptForPlanUsageOnVehicleChangePopupComponent)
             }
         }
+        */
 
         function waitingOnIncompleteDataMessage(save) {
             var saveOrUpload = save ? qsTr("Save") : qsTr("Upload")

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -1053,7 +1053,7 @@ Item {
                         map:            editorMap
                         masterController:  _planMasterController
                         missionItem:    object
-                        width:          parent.width
+                        width:          parent ? parent.width : 0
                         readOnly:       false
                         onClicked:      _missionController.setCurrentPlanViewSeqNum(object.sequenceNumber, false)
                         onRemove: {

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -478,10 +478,6 @@ Item {
             fileDialog.nameFilters =    ShapeFileHelper.fileDialogKMLFilters
             fileDialog.openForSave()
         }
-
-        function browseKyteOrders() {
-            mainWindow.showPopupDialogFromComponent(promptForBrowsingKyteOrders)
-        }
     }
 
     Connections {
@@ -1404,7 +1400,7 @@ Item {
                     enabled:            !_planMasterController.syncInProgress && _aviantSettings.kyteBackendUrl.rawValue != ""
                     onClicked: {
                         dropPanel.hide()
-                        _planMasterController.browseKyteOrders()
+                        mainWindow.showPopupDialogFromComponent(promptForBrowsingKyteOrders)
                     }
                 }
             }

--- a/src/PlanView/RallyPointMapVisuals.qml
+++ b/src/PlanView/RallyPointMapVisuals.qml
@@ -46,12 +46,16 @@ Item {
 
         MissionItemIndicatorDrag {
             mapControl:     _root.map
-            itemCoordinate: rallyPointObject.coordinate
+            itemCoordinate: rallyPointObject ? rallyPointObject.coordinate : null
             visible:        rallyPointObject === myRallyPointController.currentRallyPoint && _root.interactive
 
             property var rallyPointObject
 
-            onItemCoordinateChanged: rallyPointObject.coordinate = itemCoordinate
+            onItemCoordinateChanged: {
+                if (rallyPointObject) {
+                    rallyPointObject.coordinate = itemCoordinate
+                }
+            }
         }
     }
 
@@ -70,11 +74,15 @@ Item {
             sourceItem: MissionItemIndexLabel {
                 id:                 itemIndexLabel
                 // Rally point types: 0=Always, 1=MR only, 2=FW only
-                label:              rallyPointObject.type == 2 ? "F" : rallyPointObject.type == 1 ? "M" : "R"
-                important:          rallyPointObject.type == 2
-                checked:            _editingLayer == _layerRallyPoints ? rallyPointObject === myRallyPointController.currentRallyPoint : false
+                label:              rallyPointObject && rallyPointObject.type !== undefined
+                                    ? (rallyPointObject.type == 2 ? "F" : rallyPointObject.type == 1 ? "M" : "R")
+                                    : "R"
+                important:          rallyPointObject ? (rallyPointObject.type == 2) : false
+                checked:            rallyPointObject
+                                    ? (_editingLayer == _layerRallyPoints ? rallyPointObject === myRallyPointController.currentRallyPoint : false)
+                                    : false
                 highlightSelected:  true
-                onClicked:          myRallyPointController.currentRallyPoint = rallyPointObject
+                onClicked:          if (rallyPointObject) { myRallyPointController.currentRallyPoint = rallyPointObject }
             }
         }
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2266,18 +2266,49 @@ void Vehicle::_missionManagerError(int errorCode, const QString& errorMsg)
 {
     Q_UNUSED(errorCode);
     qgcApp()->showAppMessage(tr("Mission transfer failed. Error: %1").arg(errorMsg));
+    if (_missionManagerErrorMsg != errorMsg) {
+        _missionManagerErrorMsg = errorMsg;
+        emit missionManagerErrorChanged();
+    }
+}
+
+void Vehicle::clearMissionManagerError()
+{
+    _missionManagerErrorMsg = "";
+    emit missionManagerErrorChanged();
 }
 
 void Vehicle::_geoFenceManagerError(int errorCode, const QString& errorMsg)
 {
     Q_UNUSED(errorCode);
     qgcApp()->showAppMessage(tr("GeoFence transfer failed. Error: %1").arg(errorMsg));
+    if (_geoFenceManagerErrorMsg != errorMsg) {
+        _geoFenceManagerErrorMsg = errorMsg;
+        emit geoFenceManagerErrorChanged();
+    }
+}
+
+void Vehicle::clearGeoFenceManagerError()
+{
+    _geoFenceManagerErrorMsg = "";
+    emit geoFenceManagerErrorChanged();
 }
 
 void Vehicle::_rallyPointManagerError(int errorCode, const QString& errorMsg)
 {
     Q_UNUSED(errorCode);
     qgcApp()->showAppMessage(tr("Rally Point transfer failed. Error: %1").arg(errorMsg));
+    if (_rallyPointManagerErrorMsg != errorMsg) {
+        qDebug() << "Rally Point transfer failed. Error: " << errorMsg;
+        _rallyPointManagerErrorMsg = errorMsg;
+        emit rallyPointManagerErrorChanged();
+    }
+}
+
+void Vehicle::clearRallyPointManagerError()
+{
+    _rallyPointManagerErrorMsg = "";
+    emit rallyPointManagerErrorChanged();
 }
 
 void Vehicle::_clearCameraTriggerPoints()

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -259,6 +259,9 @@ public:
     Q_PROPERTY(bool                 requiresGpsFix              READ requiresGpsFix                                                 NOTIFY requiresGpsFixChanged)
     Q_PROPERTY(double               loadProgress                READ loadProgress                                                   NOTIFY loadProgressChanged)
     Q_PROPERTY(bool                 initialConnectComplete      READ isInitialConnectComplete                                       NOTIFY initialConnectComplete)
+    Q_PROPERTY(QString              missionManagerError         READ missionManagerError                                            NOTIFY missionManagerErrorChanged)
+    Q_PROPERTY(QString              geoFenceManagerError        READ geoFenceManagerError                                           NOTIFY geoFenceManagerErrorChanged)
+    Q_PROPERTY(QString              rallyPointManagerError      READ rallyPointManagerError                                         NOTIFY rallyPointManagerErrorChanged)
 
     // The following properties relate to Orbit status
     Q_PROPERTY(bool             orbitActive     READ orbitActive        NOTIFY orbitActiveChanged)
@@ -526,6 +529,10 @@ public:
     QString prearmError() const { return _prearmError; }
     void setPrearmError(const QString& prearmError);
 
+    void clearRallyPointManagerError();
+    void clearGeoFenceManagerError();
+    void clearMissionManagerError();
+
     QmlObjectListModel* cameraTriggerPoints () { return &_cameraTriggerPoints; }
 
     int  flowImageIndex() const{ return _flowImageIndex; }
@@ -559,6 +566,9 @@ public:
     int             messageCount                () const{ return _messageCount; }
     QString         formattedMessages           ();
     QString         latestError                 () { return _latestError; }
+    QString         missionManagerError         () const { return _missionManagerErrorMsg; }
+    QString         rallyPointManagerError      () const { return _rallyPointManagerErrorMsg; }
+    QString         geoFenceManagerError        () const { return _geoFenceManagerErrorMsg; }
     float           latitude                    () { return static_cast<float>(_coordinate.latitude()); }
     float           longitude                   () { return static_cast<float>(_coordinate.longitude()); }
     bool            mavPresent                  () { return _mav != nullptr; }
@@ -853,6 +863,9 @@ public slots:
     void handleNewCriticalVehicleMessage    (UASMessage* message);
 
 signals:
+    void missionManagerErrorChanged();
+    void geoFenceManagerErrorChanged();
+    void rallyPointManagerErrorChanged();
     void coordinateChanged              (QGeoCoordinate coordinate);
     void positionSetpointChanged        (QGeoCoordinate positionSetpoint);
     void joystickEnabledChanged         (bool enabled);
@@ -1119,7 +1132,9 @@ private:
     bool            _readyToFlyAvailable                    = false;
     bool            _readyToFly                             = false;
     bool            _allSensorsHealthy                      = true;
-
+    QString         _missionManagerErrorMsg;
+    QString         _geoFenceManagerErrorMsg;
+    QString         _rallyPointManagerErrorMsg;
     SysStatusSensorInfo _sysStatusSensorInfo;
 
     QGCCameraManager* _cameraManager = nullptr;

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -58,7 +58,19 @@ RowLayout {
                     }
                 } else {
                     if (_activeVehicle.readyToFlyAvailable) {
-                        if (_activeVehicle.readyToFly) {
+                        if (_activeVehicle.missionManagerError) {
+                            _mainStatusBGColor = "red"
+                            return "Error syncing mission: " + _activeVehicle.missionManagerError
+                        }
+                        else if (_activeVehicle.geoFenceManagerError) {
+                            _mainStatusBGColor = "red"
+                            return "Error syncing geofence: " + _activeVehicle.geoFenceManagerError
+                        }
+                        else if (_activeVehicle.rallyPointManagerError) {
+                            _mainStatusBGColor = "red"
+                            return "Error syncing rally points: " + _activeVehicle.rallyPointManagerError
+                        }
+                        else if (_activeVehicle.readyToFly) {
                             _mainStatusBGColor = "green"
                             return mainStatusLabel._readyToFlyText
                         } else {

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -27,6 +27,9 @@ RowLayout {
     property real   _margins:           ScreenTools.defaultFontPixelWidth
     property real   _spacing:           ScreenTools.defaultFontPixelWidth / 2
 
+    property var    _planMasterController: globals.planMasterControllerPlanView
+    property bool   _syncInProgress:       _planMasterController.syncInProgress
+
     QGCLabel {
         id:             mainStatusLabel
         text:           mainStatusText()
@@ -58,7 +61,11 @@ RowLayout {
                     }
                 } else {
                     if (_activeVehicle.readyToFlyAvailable) {
-                        if (_activeVehicle.missionManagerError) {
+                        if (_syncInProgress) {
+                            _mainStatusBGColor = "yellow"
+                            return "Syncing mission..."
+                        }
+                        else if (_activeVehicle.missionManagerError) {
                             _mainStatusBGColor = "red"
                             return "Error syncing mission: " + _activeVehicle.missionManagerError
                         }

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -29,6 +29,8 @@ RowLayout {
 
     property var    _planMasterController: globals.planMasterControllerPlanView
     property bool   _syncInProgress:       _planMasterController.syncInProgress
+    property bool   _dirty:                _planMasterController.dirty
+
 
     QGCLabel {
         id:             mainStatusLabel
@@ -76,6 +78,10 @@ RowLayout {
                         else if (_activeVehicle.rallyPointManagerError) {
                             _mainStatusBGColor = "red"
                             return "Error syncing rally points: " + _activeVehicle.rallyPointManagerError
+                        }
+                        else if (_dirty) {
+                            _mainStatusBGColor = "yellow"
+                            return qsTr("Mission not uploaded to vehicle")
                         }
                         else if (_activeVehicle.readyToFly) {
                             _mainStatusBGColor = "green"

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -223,16 +223,11 @@ Rectangle {
 
         // Geofence download progress
         Rectangle {
+            id:      geoFenceProgressBar
             height:  parent.height / 2
             color:   qgcPal.colorBlue
             width:   _geoFenceControllerProgressPct * parent.width
-            visible: _geoFenceControllerProgressPct > 0 && _geoFenceControllerProgressPct < 1 && 
-
-            QGCLabel {
-                anchors.centerIn: parent
-                text:             qsTr("Geofence Downloading: %1%").arg(Math.round(_geoFenceControllerProgressPct * 100))
-                font.pointSize:   ScreenTools.defaultFontPointSize
-            }
+            visible: _geoFenceControllerProgressPct > 0 && _geoFenceControllerProgressPct < 1
         }
         
         // Rally point download progress
@@ -241,12 +236,6 @@ Rectangle {
             color:   qgcPal.colorBlue
             width:   _rallyPointControllerProgressPct * parent.width
             visible: _rallyPointControllerProgressPct > 0 && _rallyPointControllerProgressPct < 1
-
-            QGCLabel {
-                anchors.centerIn: parent
-                text:             qsTr("Rally point Downloading: %1%").arg(Math.round(_rallyPointControllerProgressPct * 100))
-                font.pointSize:   ScreenTools.defaultFontPointSize
-            }
         }
         
         // Mission download progress
@@ -255,26 +244,40 @@ Rectangle {
             color:   qgcPal.colorBlue
             width:   _missionControllerProgressPct * parent.width
             visible: _missionControllerProgressPct > 0 && _missionControllerProgressPct < 1
-
-            QGCLabel {
-                anchors.centerIn: parent
-                text:             qsTr("Mission Downloading: %1%").arg(Math.round(_missionControllerProgressPct * 100))
-                font.pointSize:   ScreenTools.defaultFontPointSize
-            }
         }
 
         // Parameter download progress
         Rectangle {
+            id:      parameterProgressBar
             height:  parent.height / 2
             y:       parent.height / 2
             color:   qgcPal.colorBlue
             width:   _activeVehicle ? _activeVehicle.loadProgress * parent.width : 0
+        }
 
-            QGCLabel {
-                anchors.centerIn: parent
-                text:             qsTr("Parameter Downloading: %1%").arg(Math.round((_activeVehicle ? _activeVehicle.loadProgress : 0) * 100))
-                font.pointSize:   ScreenTools.defaultFontPointSize
+        QGCLabel {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter:   geoFenceProgressBar.verticalCenter
+            text: {
+                if (_geoFenceControllerProgressPct > 0 && _geoFenceControllerProgressPct < 1) {
+                    return qsTr("Geofence Downloading: %1%").arg(Math.round(_geoFenceControllerProgressPct * 100))
+                } else if (_rallyPointControllerProgressPct > 0 && _rallyPointControllerProgressPct < 1) {
+                    return qsTr("Rally point Downloading: %1%").arg(Math.round(_rallyPointControllerProgressPct * 100))
+                } else if (_missionControllerProgressPct > 0 && _missionControllerProgressPct < 1) {
+                    return qsTr("Mission Downloading: %1%").arg(Math.round(_missionControllerProgressPct * 100))
+                } else {
+                    return ""
+                }
             }
+            font.pointSize: ScreenTools.defaultFontPointSize
+        }
+
+        // Label for parameter downloading
+        QGCLabel {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter:   parameterProgressBar.verticalCenter
+            text: qsTr("Parameter Downloading: %1%").arg(Math.round((_activeVehicle ? _activeVehicle.loadProgress : 0) * 100))
+            font.pointSize: ScreenTools.defaultFontPointSize
         }
 
         QGCLabel {

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -29,12 +29,13 @@ Rectangle {
     readonly property int planViewToolbar:  1
     readonly property int simpleToolbar:    2
 
-    property var    _activeVehicle:                 QGroundControl.multiVehicleManager.activeVehicle
-    property bool   _communicationLost:             _activeVehicle ? _activeVehicle.vehicleLinkManager.communicationLost : false
-    property color  _mainStatusBGColor:             qgcPal.brandingPurple
-    property var    _planMasterController:          globals.planMasterControllerPlanView
-    property bool   _controllerValid:              _planMasterController !== undefined && _planMasterController !== null
-    property real   _missionControllerProgressPct: (_controllerValid && _planMasterController) ? _planMasterController.missionController.progressPct : 0
+    property var    _activeVehicle:                   QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _communicationLost:               _activeVehicle ? _activeVehicle.vehicleLinkManager.communicationLost : false
+    property color  _mainStatusBGColor:               qgcPal.brandingPurple
+    property var    _planMasterController:            globals.planMasterControllerPlanView
+    property bool   _controllerValid:                 _planMasterController !== undefined && _planMasterController !== null
+    property real   _missionControllerProgressPct:    (_controllerValid && _planMasterController) ? _planMasterController.missionController.progressPct : 0
+    property real   _rallyPointControllerProgressPct: (_controllerValid && _planMasterController) ? _planMasterController.rallyPointController.progressPct : 0
 
     QGCPalette { id: qgcPal }
 
@@ -163,6 +164,14 @@ Rectangle {
             }
         }
     }
+    // Rally point download progress bar
+    Rectangle {
+        anchors.bottom: parent.bottom
+        height:         _root.height * 0.075
+        width:          _rallyPointControllerProgressPct * parent.width
+        color:          qgcPal.colorBlue
+        visible:        _rallyPointControllerProgressPct > 0 && _rallyPointControllerProgressPct < 1 && !largeProgressBar.visible
+    }
 
     // Mission download progress bar
     Rectangle {
@@ -199,6 +208,20 @@ Rectangle {
         Connections {
             target:                 QGroundControl.multiVehicleManager
             function onActiveVehicleChanged(activeVehicle) { largeProgressBar._userHide = false }
+        }
+
+        // Rally point download progress
+        Rectangle {
+            height:  parent.height / 2
+            color:   qgcPal.colorBlue
+            width:   _rallyPointControllerProgressPct * parent.width
+            visible: _rallyPointControllerProgressPct > 0 && _rallyPointControllerProgressPct < 1
+
+            QGCLabel {
+                anchors.centerIn: parent
+                text:             qsTr("Rally point Downloading: %1%").arg(Math.round(_rallyPointControllerProgressPct * 100))
+                font.pointSize:   ScreenTools.defaultFontPointSize
+            }
         }
         
         // Mission download progress

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -36,6 +36,7 @@ Rectangle {
     property bool   _controllerValid:                 _planMasterController !== undefined && _planMasterController !== null
     property real   _missionControllerProgressPct:    (_controllerValid && _planMasterController) ? _planMasterController.missionController.progressPct : 0
     property real   _rallyPointControllerProgressPct: (_controllerValid && _planMasterController) ? _planMasterController.rallyPointController.progressPct : 0
+    property real   _geoFenceControllerProgressPct:   (_controllerValid && _planMasterController) ? _planMasterController.geoFenceController.progressPct : 0
 
     QGCPalette { id: qgcPal }
 
@@ -164,6 +165,16 @@ Rectangle {
             }
         }
     }
+
+     // Geofence download progress bar
+    Rectangle {
+        anchors.bottom: parent.bottom
+        height:         _root.height * 0.075
+        width:          _geoFenceControllerProgressPct * parent.width
+        color:          qgcPal.colorBlue
+        visible:        _geoFenceControllerProgressPct > 0 && _geoFenceControllerProgressPct < 1 && !largeProgressBar.visible
+    }
+
     // Rally point download progress bar
     Rectangle {
         anchors.bottom: parent.bottom
@@ -210,6 +221,20 @@ Rectangle {
             function onActiveVehicleChanged(activeVehicle) { largeProgressBar._userHide = false }
         }
 
+        // Geofence download progress
+        Rectangle {
+            height:  parent.height / 2
+            color:   qgcPal.colorBlue
+            width:   _geoFenceControllerProgressPct * parent.width
+            visible: _geoFenceControllerProgressPct > 0 && _geoFenceControllerProgressPct < 1 && 
+
+            QGCLabel {
+                anchors.centerIn: parent
+                text:             qsTr("Geofence Downloading: %1%").arg(Math.round(_geoFenceControllerProgressPct * 100))
+                font.pointSize:   ScreenTools.defaultFontPointSize
+            }
+        }
+        
         // Rally point download progress
         Rectangle {
             height:  parent.height / 2


### PR DESCRIPTION
This PR adds multiple features to prevent us from flying with unexpected mission/rallypoint/geofence:
- Block arming when sync is in progress
- Block arming when mission is dirty
- Block arming if error happened during sync
- Display sync status of rally points and geofence
- Display sync status in both flyview and planview
- Remove popup asking to discard or overwrite current plan, change to always keep current plan

Also some minor fixes:
- Clear missionfilename when downloading new mission from kyte
- Clear missionfilename when clearing mission
