### PR TITLE
feat: face tangent to circle during orbit

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2632,7 +2632,7 @@ void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, 
                     true,                           // show error if fails
                     static_cast<float>(radius),
                     static_cast<float>(qQNaN()),    // Use default velocity
-                    0,                              // Vehicle points to center
+                    3,                              // Vehicle points tangentially to circle
                     static_cast<float>(qQNaN()),    // reserved
                     centerCoord.latitude(), centerCoord.longitude(), static_cast<float>(amslAltitude));
     } else {
@@ -2642,7 +2642,7 @@ void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, 
                     true,                           // show error if fails
                     static_cast<float>(radius),
                     static_cast<float>(qQNaN()),    // Use default velocity
-                    0,                              // Vehicle points to center
+                    3,                              // Vehicle points tangentially to circle
                     static_cast<float>(qQNaN()),    // reserved
                     static_cast<float>(centerCoord.latitude()),
                     static_cast<float>(centerCoord.longitude()),


### PR DESCRIPTION
This will make the drone point tangentially to the circle during ORBIT. The current default is to face the center of the circle.

See [ORBIT_YAW_BEHAVIOUR](https://mavlink.io/en/messages/common.html#ORBIT_YAW_BEHAVIOUR).

Tested in sim on desktop.