### PR TITLE
Mark old adsb vehicles

### DIFF
--- a/src/ADSB/ADSBVehicle.cc
+++ b/src/ADSB/ADSBVehicle.cc
@@ -31,6 +31,8 @@ void ADSBVehicle::update(const VehicleInfo_t& vehicleInfo)
         return;
     }
 
+    setIsOldSignal(false);
+
 	if (vehicleInfo.emitterType != _emitterType) {
             _emitterType = vehicleInfo.emitterType;
             emit emitterTypeChanged();
@@ -67,6 +69,24 @@ void ADSBVehicle::update(const VehicleInfo_t& vehicleInfo)
         }
     }
     _lastUpdateTimer.restart();
+}
+
+bool ADSBVehicle::isOldSignal()
+{
+    return _lastUpdateTimer.hasExpired(oldSignalMs);
+}
+
+void ADSBVehicle::setIsOldSignal(bool isOldSignal)
+{
+    if (_oldSignal != isOldSignal) {
+        if (!isOldSignal && _oldSignal) {
+            qCDebug(ADSBVehicleManagerLog) << "Signal restored" << QStringLiteral("%1").arg(_icaoAddress, 0, 16);
+        } else {
+            qCDebug(ADSBVehicleManagerLog) << "Old signal" << QStringLiteral("%1").arg(_icaoAddress, 0, 16);
+        }
+        _oldSignal = isOldSignal;
+        emit oldSignalChanged();
+    }
 }
 
 bool ADSBVehicle::expired()

--- a/src/ADSB/ADSBVehicle.h
+++ b/src/ADSB/ADSBVehicle.h
@@ -74,7 +74,8 @@ public:
     Q_PROPERTY(bool             alert       READ alert          NOTIFY alertChanged)        // Collision path
     Q_PROPERTY(bool             hidden      READ hidden         NOTIFY hiddenChanged)       // Hidden from fly view map
     Q_PROPERTY(EmitterType      emitterType READ emitterType    NOTIFY emitterTypeChanged)  // Vechicle type (MAVLink ADSB_EMITTER_TYPE)
-
+    Q_PROPERTY(bool             oldSignal   READ oldSignal      NOTIFY oldSignalChanged)    // True if the vehicle has not been updated for a while
+    
     int             icaoAddress (void) const { return static_cast<int>(_icaoAddress); }
     QString         callsign    (void) const { return _callsign; }
     QGeoCoordinate  coordinate  (void) const { return _coordinate; }
@@ -83,12 +84,17 @@ public:
     bool            alert       (void) const { return _alert; }
     bool            hidden      (void) const { return _hidden; }
     EmitterType     emitterType (void) const { return _emitterType; }
-
+    bool            oldSignal   (void) const { return _oldSignal; }
+    
     void update(const VehicleInfo_t& vehicleInfo);
     void setHidden(bool hidden);
+    void setIsOldSignal(bool isOld);
 
     /// check if the vehicle is expired and should be removed
     bool expired();
+    // Check if the vehicle is old and should be marked as such
+    bool isOldSignal();
+
 
 signals:
     void coordinateChanged  ();
@@ -98,6 +104,7 @@ signals:
     void alertChanged       ();
     void hiddenChanged      ();
     void emitterTypeChanged ();
+    void oldSignalChanged   ();
 
 private:
     uint32_t        _icaoAddress;
@@ -107,10 +114,13 @@ private:
     double          _heading;
     bool            _alert;
     bool            _hidden = false;
+    bool            _oldSignal = false;
     EmitterType     _emitterType;
 
     QElapsedTimer   _lastUpdateTimer;
 
+
+    static constexpr qint64 oldSignalMs = 60000;   ///< timeout with no update in ms after which the vehicle is marked as old.
     static constexpr qint64 expirationTimeoutMs = 120000;   ///< timeout with no update in ms after which the vehicle is removed.
                                                             ///< AirMap sends updates for each vehicle every second.
 };

--- a/src/ADSB/ADSBVehicle.h
+++ b/src/ADSB/ADSBVehicle.h
@@ -121,7 +121,7 @@ private:
 
 
     static constexpr qint64 oldSignalMs = 60000;   ///< timeout with no update in ms after which the vehicle is marked as old.
-    static constexpr qint64 expirationTimeoutMs = 120000;   ///< timeout with no update in ms after which the vehicle is removed.
+    static constexpr qint64 expirationTimeoutMs = 240000;   ///< timeout with no update in ms after which the vehicle is removed.
                                                             ///< AirMap sends updates for each vehicle every second.
 };
 

--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -39,7 +39,7 @@ void ADSBVehicleManager::setToolbox(QGCToolbox* toolbox)
 
 void ADSBVehicleManager::_cleanupStaleVehicles()
 {
-    // Remove all expired ADSB vehicles
+    // Remove all expired ADSB vehicles, and mark old ones
     for (int i=_adsbVehicles.count()-1; i>=0; i--) {
         ADSBVehicle* adsbVehicle = _adsbVehicles.value<ADSBVehicle*>(i);
         if (adsbVehicle->expired()) {
@@ -47,6 +47,13 @@ void ADSBVehicleManager::_cleanupStaleVehicles()
             _adsbVehicles.removeAt(i);
             _adsbICAOMap.remove(adsbVehicle->icaoAddress());
             adsbVehicle->deleteLater();
+        }
+        else {
+            if (adsbVehicle->isOldSignal()) {
+                adsbVehicle->setIsOldSignal(true);
+            } else {
+                adsbVehicle->setIsOldSignal(false);
+            }
         }
     }
 }

--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -659,6 +659,7 @@ FlightMap {
             map:            _root
             z:              QGroundControl.zOrderVehicles
             visible:        object ? !object.hidden : false
+            oldSignal:      object ? object.oldSignal : false
         }
     }
 

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -32,6 +32,7 @@ MapQuickItem {
     property bool   alert:          false                                           /// Collision alert
     property var    emitterType:    ADSBVehicle.EMITTER_TYPE_NO_INFO
     property int    icaoAddress                                                     /// ICAO address for ADSB vehicle
+    property bool   oldSignal:      false                                           /// True if the signal is old
     property var    adsbVehicleManager: QGroundControl.adsbVehicleManager
 
     anchorPoint.x:  vehicleItem.width  / 2
@@ -58,8 +59,13 @@ MapQuickItem {
         id:         vehicleItem
         width:      vehicleIcon.width
         height:     vehicleIcon.height
-        opacity:    _adsbVehicle || vehicle === _activeVehicle ? 1.0 : 0.5
-
+        opacity:    {
+            if (_adsbVehicle) {
+                return oldSignal ? 0.4 : 1.0
+            } else {
+                return vehicle === _activeVehicle ? 1.0 : 0.5
+            }
+        }
         Rectangle {
             id:                 vehicleShadow
             anchors.fill:       vehicleIcon
@@ -175,7 +181,7 @@ MapQuickItem {
             title: qsTr("Hide vehicle " + callsign + "?")
             buttons:    StandardButton.Yes | StandardButton.No
 
-            QGCLabel { text: qsTr("You can unhide it in the toolbar") }
+            QGCLabel { text: qsTr("You can unhide it in the toolbar.") }
 
             function accept() {
                 if (adsbVehicleManager && icaoAddress) {
@@ -183,7 +189,7 @@ MapQuickItem {
                 } else {
                     mainWindow.showMessageDialog(qsTr("Error"), qsTr("ADSB vehicle manager or icao address not found"))
                     console.log("ADSB vehicle manager or icao address not found")
-                }                
+                }
                 hideDialog()
             }
             function reject() {


### PR DESCRIPTION
It was reported that the pilot often had to rehide hidden vehicles, as they would be removed when no signal was received for two minutes, and then they would reappear. This PR therefore increases the expiration time to four minutes, to reduce the chance of this happens. This makes the stale vehicles appear for a long time, so we therefore mark vehicles with signal older than one minute as "old", reducing the opacity of their icon to 30%.