### PR TITLE
Separate winch and takeoff types in Aviant mission tools

### DIFF
--- a/src/MissionManager/AviantMissionTools.h
+++ b/src/MissionManager/AviantMissionTools.h
@@ -37,21 +37,32 @@ public:
         FetchKyteOrderMissionFile
     };
 
-    enum MissionType {
-        NotSet,
-        FixedWing,
-        Winch,
-        CustomWinch
+    enum TakeoffType {
+        TakeoffTypeNotSet,
+        VTOL,
+        Headless
+    };
+    
+    enum WinchType {
+        WinchTypeNotSet,
+        NoWinch,
+        V1,
+        V2,
+        V3,
+        Custom
     };
 
     Q_ENUM(Operation)
-    Q_ENUM(MissionType)
+    Q_ENUM(TakeoffType)
+    Q_ENUM(WinchType)
     
     Q_PROPERTY(PlanMasterController* masterController  READ masterController  CONSTANT)
     Q_PROPERTY(bool                  requestInProgress READ requestInProgress                      NOTIFY   stateChanged)
     Q_PROPERTY(Operation             currentOperation  READ currentOperation                       NOTIFY   stateChanged)
-    Q_PROPERTY(MissionType           missionType       READ missionType       WRITE setMissionType NOTIFY   stateChanged)
-    Q_PROPERTY(QStringList           missionTypeList   READ missionTypeList   CONSTANT)
+    Q_PROPERTY(TakeoffType           takeoffType       READ takeoffType       WRITE setTakeoffType NOTIFY   stateChanged)
+    Q_PROPERTY(WinchType             winchType         READ winchType         WRITE setWinchType   NOTIFY   stateChanged)
+    Q_PROPERTY(QStringList           takeoffTypeList   READ takeoffTypeList   CONSTANT)
+    Q_PROPERTY(QStringList           winchTypeList     READ winchTypeList     CONSTANT)
     Q_PROPERTY(QString               validationResult  READ validationResult                       NOTIFY   stateChanged)
     
     Q_INVOKABLE void requestOperation(Operation operation);
@@ -62,9 +73,12 @@ public:
     PlanMasterController* masterController       (void) const { return _masterController; }
     bool                  requestInProgress      (void) const { return _currentOperation != NoOperation; }
     Operation             currentOperation       (void) const { return _currentOperation; }
-    MissionType           missionType            (void) const { return _missionType; }
-    QStringList           missionTypeList        (void) const;
-    void                  setMissionType         (MissionType missionType);
+    TakeoffType           takeoffType            (void) const { return _takeoffType; }
+    WinchType             winchType              (void) const { return _winchType; }
+    QStringList           takeoffTypeList        (void) const;
+    QStringList           winchTypeList          (void) const;
+    void                  setTakeoffType         (TakeoffType takeoffType);
+    void                  setWinchType           (WinchType winchType);
     QString               validationResult       (void) const { return _validationResult; }
 
 signals:
@@ -82,15 +96,18 @@ private:
     void           _parseValidationResponse     (const QByteArray &bytes);
     void           _parseAndLoadMissionResponse (const QByteArray &bytes);
     static QString _getOperationName            (Operation operation);
-    static QString _getMissionTypeName          (MissionType missionType);
-    static bool    _missionTypeRequired(Operation operation);
+    static QString _getTakeoffTypeName          (TakeoffType takeoffType);
+    static QString _getWinchTypeName            (WinchType winchType);
+    static bool    _takeoffTypeRequired(Operation operation);
+    static bool    _winchTypeRequired(Operation operation);
     void           _parseKyteOrdersResponse(const QByteArray &bytes);
     bool           _validateFileHash(const QByteArray &fileData, const QByteArray &expectedHash);
     void           _initiateNetworkRequest(Operation operationType, const QUrl& url);
 
     PlanMasterController*   _masterController;
     Operation               _currentOperation =     NoOperation;
-    MissionType             _missionType =          NotSet;
+    TakeoffType             _takeoffType =          TakeoffTypeNotSet;
+    WinchType               _winchType =            WinchTypeNotSet;
     QNetworkAccessManager*  _networkAccessManager = nullptr;
     QNetworkRequest         _networkRequest;
     QString                 _validationResult =     "Not validated";

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -1474,8 +1474,14 @@ Item {
             spacing:    _margin
             width:      Math.min(_validationPanelMaxWidth, Math.max(_validationPanelMinWidth, validationSummaryLabel.implicitWidth))
 
+            function typesSet() {
+                if (_aviantMissionTools.takeoffType == AviantMissionTools.TakeoffTypeNotSet) return false
+                if (_aviantMissionTools.winchType == AviantMissionTools.WinchTypeNotSet) return false
+                return true
+            }
+
             Component.onCompleted: {
-                if (_aviantMissionTools.missionType != AviantMissionTools.NotSet) {
+                if (typesSet()) {
                     _aviantMissionTools.requestOperation(AviantMissionTools.MissionValidation)
                 }
             }
@@ -1486,44 +1492,57 @@ Item {
                 text:               qsTr("Mission Validation")
             }
 
-            ColumnLayout { 
-                visible:            missionValidationSection.checked
-                spacing:    _margin
-            
-                RowLayout {
-                    Layout.fillWidth:   true
-                    spacing:            _margin
+            GridLayout {
+                columns:           2
+                Layout.fillWidth:  true
 
-                    QGCLabel {
-                        text:               qsTr("Mission type:")
-                    }
-
-                    QGCComboBox {
-                        sizeToContents:     true
-                        model:              _aviantMissionTools.missionTypeList
-                        currentIndex:       _aviantMissionTools.missionType
-                        onActivated: {
-                            _aviantMissionTools.missionType = index
-                             if (_aviantMissionTools.missionType != AviantMissionTools.NotSet) {
-                                 _aviantMissionTools.requestOperation(AviantMissionTools.MissionValidation)
-                             }
-                        }
-                    }
-                }
-                
                 QGCLabel {
-                    id:                 validationSummaryLabel
-                    Layout.fillWidth:   true
-                    text:               _aviantMissionTools.validationResult
+                    Layout.preferredWidth:  parent.width / 4
+                    text:                   qsTr("Takeoff type:")
                 }
 
-                QGCButton {
-                    text:               qsTr("Cancel")
-                    Layout.fillWidth:   true
-                    visible:            _aviantMissionTools.currentOperation == AviantMissionTools.MissionValidation
-                    onClicked: {
-                        _aviantMissionTools.cancelOperation(AviantMissionTools.MissionValidation)
+                QGCComboBox {
+                    Layout.fillWidth:  true
+                    model:             _aviantMissionTools.takeoffTypeList
+                    currentIndex:      _aviantMissionTools.takeoffType
+                    onActivated: {
+                        _aviantMissionTools.takeoffType = index
+                         if (typesSet()) {
+                             _aviantMissionTools.requestOperation(AviantMissionTools.MissionValidation)
+                         }
                     }
+                }
+
+                QGCLabel {
+                    Layout.preferredWidth:  parent.width / 4
+                    text:                   qsTr("Winch type:")
+                }
+
+                QGCComboBox {
+                    Layout.fillWidth:   true
+                    model:              _aviantMissionTools.winchTypeList
+                    currentIndex:       _aviantMissionTools.winchType
+                    onActivated: {
+                        _aviantMissionTools.winchType = index
+                         if (typesSet()) {
+                             _aviantMissionTools.requestOperation(AviantMissionTools.MissionValidation)
+                         }
+                    }
+                }
+            }
+            
+            QGCLabel {
+                id:                 validationSummaryLabel
+                Layout.fillWidth:   true
+                text:               _aviantMissionTools.validationResult
+            }
+
+            QGCButton {
+                text:               qsTr("Cancel")
+                Layout.fillWidth:   true
+                visible:            _aviantMissionTools.currentOperation == AviantMissionTools.MissionValidation
+                onClicked: {
+                    _aviantMissionTools.cancelOperation(AviantMissionTools.MissionValidation)
                 }
             }
         }
@@ -1543,22 +1562,33 @@ Item {
                 text:               qsTr("Mission settings")
             }
             
-            RowLayout {
-                Layout.fillWidth:   true
-                spacing:            _margin
-                visible:            missionToolsSettingsSection.checked
+            GridLayout {
+                columns:           2
+                Layout.fillWidth:  true
+                visible:           missionToolsSettingsSection.checked
 
                 QGCLabel {
-                    Layout.fillWidth:   true
-                    text:               qsTr("Mission type:")
+                    Layout.preferredWidth:  parent.width / 4
+                    text:                   qsTr("Takeoff type:")
                 }
 
                 QGCComboBox {
                     Layout.fillWidth:   true
-                    sizeToContents:     true
-                    model:              _aviantMissionTools.missionTypeList
-                    currentIndex:       _aviantMissionTools.missionType
-                    onActivated:        _aviantMissionTools.missionType = index
+                    model:              _aviantMissionTools.takeoffTypeList
+                    currentIndex:       _aviantMissionTools.takeoffType
+                    onActivated:        _aviantMissionTools.takeoffType = index
+                }
+
+                QGCLabel {
+                    Layout.preferredWidth:  parent.width / 4
+                    text:                   qsTr("Winch type:")
+                }
+
+                QGCComboBox {
+                    Layout.fillWidth:   true
+                    model:              _aviantMissionTools.winchTypeList
+                    currentIndex:       _aviantMissionTools.winchType
+                    onActivated:        _aviantMissionTools.winchType = index
                 }
             }
 


### PR DESCRIPTION
Support for new validator features.

Note: Winch patterns "V2" and "V3" does not exists and will fail if used now, they are added so we do not need to upgrade QGC again if the are supported later. We might consider to query the server for valid types later, rather than hard code them.