### PR TITLE
Use utf8 as locale in docker image

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -10,13 +10,19 @@ ENV PATH /usr/lib/ccache:$QT_DESKTOP/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Oslo
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install curl libsdl2-dev gstreamer1.0-gl qt5-default libxcb-xinerama0 -y
+RUN apt-get install curl libsdl2-dev gstreamer1.0-gl qt5-default libxcb-xinerama0 locales -y
+RUN rm -rf /var/lib/apt/lists/*
 RUN groupadd -r qgc -g 1000 && useradd -m -u 1000 -r -g qgc qgc
 RUN mkdir app
 ARG APPIMAGE_PATH="./QGroundControl.AppImage"
 COPY ${APPIMAGE_PATH} /app
 RUN chmod 755 /app
 WORKDIR /app
+# Reconfigure locale
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 USER qgc
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 CMD ["./QGroundControl.AppImage"]


### PR DESCRIPTION
If not, missions with special characters do not show up in multi-command.

Test by adding a mission with `å` in its name in the Missions-folder on the desktop. When opening QGC through multi-command, this mission will not show in the Missions-file. This is because locale is:
```
qgc@Alpha:/app$ locale
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
```
With the changes in this PR, locale is is set to UTF8. This is already done in Dockerfile-build-linux, but not in Dockerfile
```
qgc@Alpha:/app$ locale
LANG=en_US.UTF-8
LANGUAGE=en_US:en
```
and missions with special characters such as `å` will show up


