### PR TITLE
chore: bump actions to ubuntu 22.04

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on:  ubuntu-20.04
+    runs-on:  ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build:
-    runs-on:  ubuntu-20.04
+    runs-on:  ubuntu-22.04
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Install QGC source dependencies
         run:  sudo apt-get install -y libsdl2-dev
 
-      - name: Install Gstreamer # Remove libunwind-* as it conflicts with libunwind14, fix seen here: https://github.com/actions/runner-images/issues/9546#issuecomment-2014940361
+      - name: Install Gstreamer and fuse # Remove libunwind-* as it conflicts with libunwind14, fix seen here: https://github.com/actions/runner-images/issues/9546#issuecomment-2014940361
         run: |
           sudo apt-get remove libunwind-*
-          sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
+          sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev libfuse2
 
       - name: Install post-link dependencies
         run:  sudo apt-get install -y binutils patchelf

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -51,8 +51,10 @@ jobs:
       - name: Install QGC source dependencies
         run:  sudo apt-get install -y libsdl2-dev
 
-      - name: Install Gstreamer
-        run:  sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
+      - name: Install Gstreamer # Remove libunwind-* as it conflicts with libunwind14, fix seen here: https://github.com/actions/runner-images/issues/9546#issuecomment-2014940361
+        run: |
+          sudo apt-get remove libunwind-*
+          sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
 
       - name: Install post-link dependencies
         run:  sudo apt-get install -y binutils patchelf


### PR DESCRIPTION
bump to ubuntu 22.04 as 20.04 is soon deprecated by github