### PR TITLE
Fix ubuntu22 multicommand crashing

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,17 +1,25 @@
-FROM ubuntu:focal
+FROM ubuntu:22.04
 USER root
 ENV QT_VERSION=5.15.2
-ENV DEBIAN_FRONTEND noninteractive
-ENV DISPLAY :99
-ENV QMAKESPEC linux-g++-64
-ENV QT_PATH /opt/Qt
-ENV QT_DESKTOP $QT_PATH/${QT_VERSION}/gcc_64
-ENV PATH /usr/lib/ccache:$QT_DESKTOP/bin:$PATH
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DISPLAY=:99
+ENV QMAKESPEC=linux-g++-64
+ENV QT_PATH=/opt/Qt
+ENV QT_DESKTOP=$QT_PATH/${QT_VERSION}/gcc_64
+ENV PATH=/usr/lib/ccache:$QT_DESKTOP/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Oslo
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install curl libsdl2-dev gstreamer1.0-gl qt5-default libxcb-xinerama0 locales -y
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y \
+    curl \
+    libsdl2-dev \
+    gstreamer1.0-gl \
+    qtbase5-dev \
+    qtchooser \
+    qt5-qmake \
+    libxcb-xinerama0 \
+    locales \
+    && rm -rf /var/lib/apt/lists/*
 RUN groupadd -r qgc -g 1000 && useradd -m -u 1000 -r -g qgc qgc
 RUN mkdir app
 ARG APPIMAGE_PATH="./QGroundControl.AppImage"

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -74,6 +74,7 @@ jobs:
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext12"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-35"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-35-ext14"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-35-ext15"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-36"
 
       - name: Create build directory

--- a/deploy/docker/Dockerfile-build-android
+++ b/deploy/docker/Dockerfile-build-android
@@ -2,7 +2,7 @@
 # QGroundControl linux build environment
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL authors="Daniel Agar <daniel@agar.ca>, Patrick José Pereira <patrickelectric@gmail.com>, Knut Hjorth <knut.hjorth@aviant.no>"
 
 ARG QT_VERSION=5.15.2

--- a/deploy/docker/Dockerfile-build-linux
+++ b/deploy/docker/Dockerfile-build-linux
@@ -2,7 +2,7 @@
 # QGroundControl linux build environment
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL authors="Daniel Agar <daniel@agar.ca>, Patrick José Pereira <patrickelectric@gmail.com>"
 
 ARG QT_VERSION=5.15.2
@@ -58,7 +58,6 @@ RUN apt update && apt -y --quiet --no-install-recommends install \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
 # Install Qt
 COPY deploy/docker/install-qt-linux.sh /tmp/qt/
 RUN /tmp/qt/install-qt-linux.sh
@@ -68,6 +67,7 @@ RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
 
 # create user with id 1000 to not run commands/generate files as root
 RUN useradd user --create-home --home-dir /home/user --shell /bin/bash --uid 1000
+
 USER user
 
 WORKDIR /project/build

--- a/deploy/docker/Dockerfile-build-linux-test
+++ b/deploy/docker/Dockerfile-build-linux-test
@@ -2,7 +2,7 @@
 # QGroundControl linux build environment
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL authors="Daniel Agar <daniel@agar.ca>, Patrick José Pereira <patrickelectric@gmail.com>"
 
 ARG QT_VERSION=5.15.2

--- a/deploy/docker/install-qt-linux.sh
+++ b/deploy/docker/install-qt-linux.sh
@@ -10,9 +10,10 @@ QT_MODULES="${QT_MODULES:-qtcharts}"
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-apt update
-apt install python3 python3-pip -y
-pip3 install aqtinstall
-aqt install --outputdir ${QT_PATH} ${QT_VERSION} ${QT_HOST} ${QT_TARGET} -m ${QT_MODULES}
+
+apt-get update
+apt-get install python3 python3-pip -y
+pip3 install setuptools wheel py7zr ninja cmake aqtinstall
+aqt install-qt ${QT_HOST} ${QT_TARGET} ${QT_VERSION} -O ${QT_PATH} -m ${QT_MODULES}
 echo "Remember to export the following to your PATH: ${QT_PATH}/${QT_VERSION}/*/bin"
 echo "export PATH=$(readlink -e ${QT_PATH}/${QT_VERSION}/*/bin/):PATH"


### PR DESCRIPTION
QGC crashed when ran from multi-command, after the github actions was upgraded to ubunutu 22. Bumping the docker images to ubuntu 22 fixed the issue for me.