### PR TITLE
Download landingpointadjusted mission from mms

### DIFF
--- a/src/MissionManager/AviantMissionTools.cc
+++ b/src/MissionManager/AviantMissionTools.cc
@@ -13,6 +13,9 @@
 #include "SettingsManager.h"
 #include "AppSettings.h"
 #include "JsonHelper.h"
+#include <QDateTime>
+
+qint64 AviantMissionTools::_requestIdCounter = 0;
 
 AviantMissionTools::AviantMissionTools(QObject* parent)
     : QObject           (parent)
@@ -451,6 +454,9 @@ void AviantMissionTools::_initiateNetworkRequest(Operation operationType, const 
     if (operationType == FetchLandingPointAdjustedMission) {
         // Use X-API-KEY for MMS
         _networkRequest.setRawHeader(QByteArray("X-API-KEY"), aviantSettings->missionToolsToken()->rawValue().toString().toUtf8());
+        // Add Request-Id header
+        QString requestId = QString::number(QDateTime::currentMSecsSinceEpoch()) + "-" + QString::number(++_requestIdCounter);
+        _networkRequest.setRawHeader(QByteArray("Request-Id"), requestId.toUtf8());
     } else {
         // Use Authorization Token for Kyte Backend
         _networkRequest.setRawHeader(QByteArray("Authorization"), QByteArray("Token ") + aviantSettings->kyteBackendToken()->rawValue().toString().toUtf8());

--- a/src/MissionManager/AviantMissionTools.cc
+++ b/src/MissionManager/AviantMissionTools.cc
@@ -72,6 +72,14 @@ QUrl AviantMissionTools::_getMmsUrl(Operation operation, QString base)
     }
 }
 
+QUrl AviantMissionTools::_getMmsUrl(Operation operation, QString base, int missionPlanId, QString aircraftName) {
+    if (operation == FetchLandingPointAdjustedMission) {
+        return QUrl(base + "/mission_plan/" + QString::number(missionPlanId) + "/download_for_aircraft/" + aircraftName);
+    } else {
+        return _getMmsUrl(operation, base);
+    }
+}
+
 QUrl AviantMissionTools::_getKyteBackendUrl(Operation operation, QString base)
 {
     switch (operation) {
@@ -80,14 +88,6 @@ QUrl AviantMissionTools::_getKyteBackendUrl(Operation operation, QString base)
         case NoOperation:
         default:
             return QUrl();
-    }
-}
-
-QUrl AviantMissionTools::_getKyteBackendUrl(Operation operation, QString base, int orderId) {
-    if (operation == FetchKyteOrderMissionFile) {
-        return QUrl(base + "/orders/api/v2/orders/" + QString::number(orderId) + "/mission-file/");
-    } else {
-        return _getKyteBackendUrl(operation, base);
     }
 }
 
@@ -100,8 +100,8 @@ QString AviantMissionTools::_getOperationName(Operation operation)
             return QString("RallyPointHeight");
         case NoOperation:
             return QString("NoOperation");
-        case FetchKyteOrderMissionFile:
-            return QString("FetchKyteOrderMissionFile");
+        case FetchLandingPointAdjustedMission:
+            return QString("FetchLandingPointAdjustedMission");
         default:
             return QString("Unknown");
     }
@@ -334,7 +334,7 @@ void AviantMissionTools::_requestComplete(QNetworkReply *reply)
         case FetchKyteOrders:
             _parseKyteOrdersResponse(bytes);
             break;
-        case FetchKyteOrderMissionFile:
+        case FetchLandingPointAdjustedMission:
             _expectedHash = reply->rawHeader("X-File-Hash");
             if (_expectedHash.isEmpty()) {
                 qgcApp()->showAppMessage(tr("No hash received with mission file"), tr("Mission Tools"));
@@ -420,7 +420,7 @@ void AviantMissionTools::_parseAndLoadMissionResponse(const QByteArray &bytes)
         return;
     }
 
-    if (_currentOperation == FetchKyteOrderMissionFile) {
+    if (_currentOperation == FetchLandingPointAdjustedMission) {
         _masterController->clearCurrentPlanFile();
     }
 
@@ -466,11 +466,17 @@ void AviantMissionTools::fetchKyteOrderMissions()
     _initiateNetworkRequest(FetchKyteOrders, url);
 }
 
-void AviantMissionTools::downloadMissionFileFromOrder(int orderId)
+void AviantMissionTools::downloadMissionFileFromOrder(int missionPlanId, const QString& aircraftName)
 {
     AviantSettings* aviantSettings = qgcApp()->toolbox()->settingsManager()->aviantSettings();
-    QUrl url = _getKyteBackendUrl(FetchKyteOrderMissionFile, aviantSettings->kyteBackendUrl()->rawValue().toString(), orderId);
-    _initiateNetworkRequest(FetchKyteOrderMissionFile, url);
+    QUrl url = _getMmsUrl(FetchLandingPointAdjustedMission, aviantSettings->missionToolsUrl()->rawValue().toString(), missionPlanId, aircraftName);
+
+    if (!url.isValid()) {
+        qDebug() << "downloadMissionFileFromOrder" << missionPlanId << "Aircraft:" << aircraftName << "URL:" << url;
+        qgcApp()->showAppMessage(tr("Could not generate valid base URL for mission download."), tr("Mission Tools Error"));
+        return;
+    }
+    _initiateNetworkRequest(FetchLandingPointAdjustedMission, url);
 }
 
 void AviantMissionTools::_parseKyteOrdersResponse(const QByteArray &bytes)

--- a/src/MissionManager/AviantMissionTools.cc
+++ b/src/MissionManager/AviantMissionTools.cc
@@ -447,7 +447,14 @@ void AviantMissionTools::_initiateNetworkRequest(Operation operationType, const 
     AviantSettings* aviantSettings = qgcApp()->toolbox()->settingsManager()->aviantSettings();
 
     _networkRequest.setUrl(url);
-    _networkRequest.setRawHeader(QByteArray("Authorization"), QByteArray("Token ") + aviantSettings->kyteBackendToken()->rawValue().toString().toUtf8());
+
+    if (operationType == FetchLandingPointAdjustedMission) {
+        // Use X-API-KEY for MMS
+        _networkRequest.setRawHeader(QByteArray("X-API-KEY"), aviantSettings->missionToolsToken()->rawValue().toString().toUtf8());
+    } else {
+        // Use Authorization Token for Kyte Backend
+        _networkRequest.setRawHeader(QByteArray("Authorization"), QByteArray("Token ") + aviantSettings->kyteBackendToken()->rawValue().toString().toUtf8());
+    }
 
     QSslConfiguration sslConf = _networkRequest.sslConfiguration();
     sslConf.setPeerVerifyMode(aviantSettings->missionToolsInsecureHttps()->rawValue().toBool() ? QSslSocket::VerifyNone : QSslSocket::AutoVerifyPeer);

--- a/src/MissionManager/AviantMissionTools.cc
+++ b/src/MissionManager/AviantMissionTools.cc
@@ -316,7 +316,12 @@ void AviantMissionTools::_requestComplete(QNetworkReply *reply)
             // Set the validation result text instead of signaling error in a pop-up
             _validationResult = tr("Error validating mission:") + "\n" + reply->errorString();
         } else {
-            qgcApp()->showAppMessage(tr("Request failed:\n") + reply->errorString(), tr("Mission Tools"));
+            QByteArray responseBody = reply->readAll(); 
+            QString errorMessage = reply->errorString();
+            if (!responseBody.isEmpty()) {
+                errorMessage += tr("\n\n%1").arg(QString::fromUtf8(responseBody));
+            }
+            qgcApp()->showAppMessage(errorMessage, tr("An error occured"));
         }
         _currentOperation = NoOperation;
         emit stateChanged();

--- a/src/MissionManager/AviantMissionTools.h
+++ b/src/MissionManager/AviantMissionTools.h
@@ -115,4 +115,5 @@ private:
     QJsonDocument           _lastValidatedJson;
     QList<QJsonObject>      _kyteOrders;
     QByteArray              _expectedHash;
+    static qint64           _requestIdCounter; // Static counter for Request-Id
 };

--- a/src/MissionManager/AviantMissionTools.h
+++ b/src/MissionManager/AviantMissionTools.h
@@ -34,7 +34,7 @@ public:
         MissionValidation,
         RallyPointHeight,
         FetchKyteOrders,
-        FetchKyteOrderMissionFile
+        FetchLandingPointAdjustedMission
     };
 
     enum TakeoffType {
@@ -68,7 +68,7 @@ public:
     Q_INVOKABLE void requestOperation(Operation operation);
     Q_INVOKABLE void cancelOperation(Operation operation);
     Q_INVOKABLE void fetchKyteOrderMissions();
-    Q_INVOKABLE void downloadMissionFileFromOrder(int orderId);
+    Q_INVOKABLE void downloadMissionFileFromOrder(int orderId, const QString& aircraftName);
 
     PlanMasterController* masterController       (void) const { return _masterController; }
     bool                  requestInProgress      (void) const { return _currentOperation != NoOperation; }
@@ -91,8 +91,8 @@ private slots:
 
 private:
     QUrl           _getMmsUrl                   (Operation operation, QString base);
+    QUrl           _getMmsUrl                   (Operation operation, QString base, int missionPlanId, QString aircraftName);
     QUrl           _getKyteBackendUrl           (Operation operation, QString base);
-    QUrl           _getKyteBackendUrl           (Operation operation, QString base, int orderId);
     void           _parseValidationResponse     (const QByteArray &bytes);
     void           _parseAndLoadMissionResponse (const QByteArray &bytes);
     static QString _getOperationName            (Operation operation);

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -242,13 +242,7 @@ Item {
 
                                 QGCLabel {
                                     Layout.preferredWidth: parent.width / 4
-                                    text:                  "Mission status"
-                                    font.bold:             true
-                                }
-
-                                QGCLabel {
-                                    Layout.preferredWidth: parent.width / 4
-                                    text:                  "Mission file"
+                                    text:                  "Mission"
                                     font.bold:             true
                                     horizontalAlignment:   Text.AlignHCenter
                                 }
@@ -290,27 +284,6 @@ Item {
                                             return formattedDate
                                         }
                                     }
-
-                                    QGCLabel {
-                                        Layout.preferredWidth: parent.width / 4
-                                        text:                  modelData && displayMissionStatus(modelData.mission_plan)
-                                        wrapMode:              Text.WordWrap
-
-                                        function displayMissionStatus(missionPlan) {
-                                            if (!missionPlan) {
-                                                return "Mission not available"
-                                            }
-                                            const qcStatus = missionPlan.qc_status
-                                            if (qcStatus) {
-                                                return qcStatus
-                                            }
-                                            const confluenceQcUrl = missionPlan.confluence_qc_url
-                                            if (confluenceQcUrl) {
-                                                return "QC in confluence"
-                                            }
-                                            return "Mission not QCed"
-                                        }
-                                    }
                                     
                                     Item {
                                         Layout.fillHeight:     true
@@ -320,9 +293,19 @@ Item {
                                             anchors.centerIn: parent
                                             id:               missionButton
                                             text:             qsTr("Select mission")
-                                            visible:          modelData && modelData.id && modelData.mission_plan
+                                            visible:          modelData && modelData.mms_mission_id
                                             onClicked: {
-                                                _aviantMissionTools.downloadMissionFileFromOrder(modelData.id)
+                                                var currentActiveVehicle = QGroundControl.multiVehicleManager ? QGroundControl.multiVehicleManager.activeVehicle : null;
+                                                var aircraftName = currentActiveVehicle ? currentActiveVehicle.name : "";
+
+                                                if (!aircraftName || aircraftName === "") {
+                                                    mainWindow.showMessageDialog(
+                                                        qsTr("Missing Aircraft Name"),
+                                                        qsTr("Cannot download mission. No active vehicle found or the active vehicle does not have a name configured.")
+                                                    )
+                                                    return; 
+                                                }
+                                                _aviantMissionTools.downloadMissionFileFromOrder(modelData.mms_mission_id, aircraftName)
                                                 hideDialog()
                                             }
                                         }
@@ -330,7 +313,7 @@ Item {
                                         QGCLabel {
                                             anchors.centerIn: parent
                                             id:               missionNotAvailableLabel
-                                            visible:          !modelData || !modelData.id || !modelData.mission_plan
+                                            visible:          !modelData || !modelData.mms_mission_id
                                             text:             "Mission not available"
                                         }
                                     }


### PR DESCRIPTION
Had to create new branch to name it according to CI/CD, this branch is based on [this](https://github.com/aviant-tech/qgroundcontrol/pull/77) branch that is now closed

* Fetch mission from mms instead of kyte backend
* Receive mission with landingpoint adjusted based on the selected aircraft and the config in FMS

Error handling:
Aircraft not found:
![image](https://github.com/user-attachments/assets/1fba00ed-5f53-4193-b20a-fce92090471e)
Mission plan id not found in mms:
![image](https://github.com/user-attachments/assets/456ecca1-6473-40ca-8ed7-5642667bf5bd)
