### PR TITLE
feat: allow separate mr and fw limit values

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -9,8 +9,8 @@ ENV QT_DESKTOP=$QT_PATH/${QT_VERSION}/gcc_64
 ENV PATH=/usr/lib/ccache:$QT_DESKTOP/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Oslo
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y \
     curl \
     libsdl2-dev \
     gstreamer1.0-gl \

--- a/src/QmlControls/FactValueGrid.cc
+++ b/src/QmlControls/FactValueGrid.cc
@@ -29,6 +29,19 @@ const char* FactValueGrid::_rangeValuesKey      = "rangeValues";
 const char* FactValueGrid::_rangeColorsKey      = "rangeColors";
 const char* FactValueGrid::_rangeIconsKey       = "rangeIcons";
 const char* FactValueGrid::_rangeOpacitiesKey   = "rangeOpacities";
+const char* FactValueGrid::_individualFwMrRangesKey = "individualFwMrRanges";
+
+// Definitions for FW specific range keys
+const char* FactValueGrid::_fwRangeValuesKey    = "fwRangeValues";
+const char* FactValueGrid::_fwRangeColorsKey    = "fwRangeColors";
+const char* FactValueGrid::_fwRangeIconsKey     = "fwRangeIcons";
+const char* FactValueGrid::_fwRangeOpacitiesKey = "fwRangeOpacities";
+
+// Definitions for MR specific range keys
+const char* FactValueGrid::_mrRangeValuesKey    = "mrRangeValues";
+const char* FactValueGrid::_mrRangeColorsKey    = "mrRangeColors";
+const char* FactValueGrid::_mrRangeIconsKey     = "mrRangeIcons";
+const char* FactValueGrid::_mrRangeOpacitiesKey = "mrRangeOpacities";
 
 const char* FactValueGrid::_deprecatedGroupKey =  "ValuesWidget";
 
@@ -138,6 +151,43 @@ void FactValueGrid::_saveValueData(QSettings& settings, InstrumentValueData* val
 
     settings.setValue(_factGroupNameKey,    value->factGroupName());
     settings.setValue(_factNameKey,         value->factName());
+    settings.setValue(_individualFwMrRangesKey, value->individualFwMrRanges());
+
+    if (value->individualFwMrRanges()) {
+        if (value->rangeType() != InstrumentValueData::NoRangeInfo) {
+            settings.setValue(_fwRangeValuesKey, value->fwRangeValues());
+        }
+        switch (value->rangeType()) {
+            case InstrumentValueData::NoRangeInfo:
+                break;
+            case InstrumentValueData::ColorRange:
+                settings.setValue(_fwRangeColorsKey, value->fwRangeColors());
+                break;
+            case InstrumentValueData::OpacityRange:
+                settings.setValue(_fwRangeOpacitiesKey, value->fwRangeOpacities());
+                break;
+            case InstrumentValueData::IconSelectRange:
+                settings.setValue(_fwRangeIconsKey, value->fwRangeIcons());
+                break;
+        }
+
+        if (value->rangeType() != InstrumentValueData::NoRangeInfo) {
+            settings.setValue(_mrRangeValuesKey, value->mrRangeValues());
+        }
+        switch (value->rangeType()) {
+            case InstrumentValueData::NoRangeInfo:
+                break;
+            case InstrumentValueData::ColorRange:
+                settings.setValue(_mrRangeColorsKey, value->mrRangeColors());
+                break;
+            case InstrumentValueData::OpacityRange:
+                settings.setValue(_mrRangeOpacitiesKey, value->mrRangeOpacities());
+                break;
+            case InstrumentValueData::IconSelectRange:
+                settings.setValue(_mrRangeIconsKey, value->mrRangeIcons());
+                break;
+        }
+    }
 }
 
 void FactValueGrid::_loadValueData(QSettings& settings, InstrumentValueData* value)
@@ -167,6 +217,45 @@ void FactValueGrid::_loadValueData(QSettings& settings, InstrumentValueData* val
     case InstrumentValueData::IconSelectRange:
         value->setRangeIcons(settings.value(_rangeIconsKey).value<QVariantList>());
         break;
+    }
+
+    value->setIndividualFwMrRanges(settings.value(_individualFwMrRangesKey, false).toBool());
+
+    if (value->individualFwMrRanges()) {
+        if (value->rangeType() != InstrumentValueData::NoRangeInfo) {
+            value->setFwRangeValues(settings.value(_fwRangeValuesKey).value<QVariantList>());
+        }
+        switch (value->rangeType()) {
+            case InstrumentValueData::NoRangeInfo:
+                break;
+            case InstrumentValueData::ColorRange:
+                value->setFwRangeColors(settings.value(_fwRangeColorsKey).value<QVariantList>());
+                break;
+            case InstrumentValueData::OpacityRange:
+                value->setFwRangeOpacities(settings.value(_fwRangeOpacitiesKey).value<QVariantList>());
+                break;
+            case InstrumentValueData::IconSelectRange:
+                value->setFwRangeIcons(settings.value(_fwRangeIconsKey).value<QVariantList>());
+                break;
+        }
+
+        // Load MR Ranges
+        if (value->rangeType() != InstrumentValueData::NoRangeInfo) {
+            value->setMrRangeValues(settings.value(_mrRangeValuesKey).value<QVariantList>());
+        }
+        switch (value->rangeType()) {
+            case InstrumentValueData::NoRangeInfo:
+                break;
+            case InstrumentValueData::ColorRange:
+                value->setMrRangeColors(settings.value(_mrRangeColorsKey).value<QVariantList>());
+                break;
+            case InstrumentValueData::OpacityRange:
+                value->setMrRangeOpacities(settings.value(_mrRangeOpacitiesKey).value<QVariantList>());
+                break;
+            case InstrumentValueData::IconSelectRange:
+                value->setMrRangeIcons(settings.value(_mrRangeIconsKey).value<QVariantList>());
+                break;
+        }
     }
 }
 

--- a/src/QmlControls/FactValueGrid.h
+++ b/src/QmlControls/FactValueGrid.h
@@ -123,8 +123,19 @@ private:
     static const char* _rangeColorsKey;
     static const char* _rangeIconsKey;
     static const char* _rangeOpacitiesKey;
+    static const char* _individualFwMrRangesKey;
 
     static const char* _deprecatedGroupKey;
+
+    static const char* _fwRangeValuesKey;
+    static const char* _fwRangeColorsKey;
+    static const char* _fwRangeIconsKey;
+    static const char* _fwRangeOpacitiesKey;
+
+    static const char* _mrRangeValuesKey;
+    static const char* _mrRangeColorsKey;
+    static const char* _mrRangeIconsKey;
+    static const char* _mrRangeOpacitiesKey;
 };
 
 QML_DECLARE_TYPE(FactValueGrid)

--- a/src/QmlControls/HorizontalFactValueGrid.qml
+++ b/src/QmlControls/HorizontalFactValueGrid.qml
@@ -163,7 +163,9 @@ T.HorizontalFactValueGrid {
             }
         }
     }
-
+    /*
+    We dont want pilots to be able to edit the limit values, as this is configured by Multi-command.
+    Comment out the code instead of removing to make rebasing to QGCv5 easier.
     QGCMouseArea {
         x:          labelValueColumnLayout.x
         y:          labelValueColumnLayout.y
@@ -185,6 +187,7 @@ T.HorizontalFactValueGrid {
             }
         }
     }
+    */
 
     Component {
         id: valueEditDialog

--- a/src/QmlControls/InstrumentValueData.cc
+++ b/src/QmlControls/InstrumentValueData.cc
@@ -164,110 +164,139 @@ void InstrumentValueData::setRangeType(RangeType rangeType)
 
 void InstrumentValueData::setRangeValues(const QVariantList& rangeValues)
 {
-    _rangeValues = rangeValues;
+    _range.values = rangeValues;
     emit rangeValuesChanged(rangeValues);
 }
 
 void InstrumentValueData::setRangeColors (const QVariantList& rangeColors)
 {
-    _rangeColors = rangeColors;
+    _range.colors = rangeColors;
     emit rangeColorsChanged(rangeColors);
 }
 
 void InstrumentValueData::setRangeIcons(const QVariantList& rangeIcons)
 {
-    _rangeIcons = rangeIcons;
+    _range.icons = rangeIcons;
     emit rangeIconsChanged(rangeIcons);
 }
 
 void InstrumentValueData::setRangeOpacities(const QVariantList& rangeOpacities)
 {
-    _rangeOpacities = rangeOpacities;
+    _range.opacities = rangeOpacities;
     emit rangeOpacitiesChanged(rangeOpacities);
 }
 
-void InstrumentValueData::_resetRangeInfo(void)
-{
-    _rangeValues.clear();
-    _rangeColors.clear();
-    _rangeOpacities.clear();
-    _rangeIcons.clear();
+void InstrumentValueData::setIndividualFwMrRanges(bool individualFwMrRanges) {
+    if (_individualFwMrRanges != individualFwMrRanges) {
+        _individualFwMrRanges = individualFwMrRanges;
+        emit individualFwMrRangesChanged(individualFwMrRanges);
+    }
+}
+
+void InstrumentValueData::_resetRangeInfoCommon(RangeSet& rangeSet) {
+    rangeSet.values.clear();
+    rangeSet.colors.clear();
+    rangeSet.opacities.clear();
+    rangeSet.icons.clear();
 
     if (_rangeType != NoRangeInfo) {
-        _rangeValues = { 0.0, 100.0 };
+        rangeSet.values = { 0.0, 100.0 };
     }
-    for (int i=0; i<_rangeValues.count() + 1; i++) {
+
+    for (int i = 0; i < rangeSet.values.count() + 1; i++) {
         switch (_rangeType) {
         case NoRangeInfo:
             break;
         case ColorRange:
-            _rangeColors.append(QColor("green"));
+            rangeSet.colors.append(QColor("green"));
             break;
         case OpacityRange:
-            _rangeOpacities.append(1.0);
+            rangeSet.opacities.append(1.0);
             break;
         case IconSelectRange:
-            _rangeIcons.append(_factValueGrid->iconNames()[0]);
+            rangeSet.icons.append(_factValueGrid->iconNames()[0]);
             break;
         }
     }
+}
 
-    emit rangeValuesChanged     (_rangeValues);
-    emit rangeColorsChanged     (_rangeColors);
-    emit rangeOpacitiesChanged  (_rangeOpacities);
-    emit rangeIconsChanged      (_rangeIcons);
+void InstrumentValueData::_resetRangeInfo(void)
+{
+    _resetRangeInfoCommon(_range);
+    _emitRangeSignals(_range, NormalRange);
+
+    if (_individualFwMrRanges) {
+        _resetRangeInfoCommon(_fwRange);
+        _emitRangeSignals(_fwRange, FwRange);
+
+        _resetRangeInfoCommon(_mrRange);
+        _emitRangeSignals(_mrRange, MrRange);
+    }
+}
+
+void InstrumentValueData::_addRangeValueCommon(RangeSet& rangeSet) {
+    if (rangeSet.values.isEmpty()) { 
+        rangeSet.values.append(0.0); 
+    } else {
+        rangeSet.values.append(rangeSet.values.last().toDouble() + 1); 
+    }
+
+    switch (_rangeType) {
+    case NoRangeInfo:
+        break;
+    case ColorRange:
+        rangeSet.colors.append(QColor("green"));
+        break;
+    case OpacityRange:
+        rangeSet.opacities.append(1.0);
+        break;
+    case IconSelectRange:
+        if (_factValueGrid && !_factValueGrid->iconNames().isEmpty()) {
+            rangeSet.icons.append(_factValueGrid->iconNames()[0]);
+        } else {
+            rangeSet.icons.append(QString());
+        }
+        break;
+    }
 }
 
 void InstrumentValueData::addRangeValue(void)
 {
-    _rangeValues.append(_rangeValues.last().toDouble() + 1);
+    _addRangeValueCommon(_range);
+    _emitRangeSignals(_range, NormalRange);
+}
+
+void InstrumentValueData::_removeRangeValueCommon(int index, RangeSet& rangeSet) {
+    if (rangeSet.values.count() < 2 || index < 0 || index >= rangeSet.values.count()) {
+        qDebug() << "_removeRangeValueCommon: Invalid index" << index << "for values count" << rangeSet.values.count();
+        return;
+    }
+
+    rangeSet.values.removeAt(index);
 
     switch (_rangeType) {
     case NoRangeInfo:
         break;
     case ColorRange:
-        _rangeColors.append(QColor("green"));
+        rangeSet.colors.removeAt(index + 1);
         break;
     case OpacityRange:
-        _rangeOpacities.append(1.0);
+        rangeSet.opacities.removeAt(index + 1);
         break;
     case IconSelectRange:
-        _rangeIcons.append(_factValueGrid->iconNames()[0]);
+        rangeSet.icons.removeAt(index + 1);
         break;
     }
-
-    emit rangeValuesChanged     (_rangeValues);
-    emit rangeColorsChanged     (_rangeColors);
-    emit rangeOpacitiesChanged  (_rangeOpacities);
-    emit rangeIconsChanged      (_rangeIcons);
 }
 
 void InstrumentValueData::removeRangeValue(int index)
 {
-    if (_rangeValues.count() < 2 || index <0 || index >= _rangeValues.count()) {
+    if (_range.values.count() < 2 || index < 0 || index >= _range.values.count()) { 
+        qDebug() << "removeRangeValue: Invalid index or not enough values.";
         return;
     }
-
-    _rangeValues.removeAt(index);
-
-    switch (_rangeType) {
-    case NoRangeInfo:
-        break;
-    case ColorRange:
-        _rangeColors.removeAt(index + 1);
-        break;
-    case OpacityRange:
-        _rangeOpacities.removeAt(index + 1);
-        break;
-    case IconSelectRange:
-        _rangeIcons.removeAt(index + 1);
-        break;
-    }
-
-    emit rangeValuesChanged     (_rangeValues);
-    emit rangeColorsChanged     (_rangeColors);
-    emit rangeOpacitiesChanged  (_rangeOpacities);
-    emit rangeIconsChanged      (_rangeIcons);
+    _removeRangeValueCommon(index, _range);
+    _emitRangeSignals(_range, NormalRange);
 }
 
 void InstrumentValueData::_updateRanges(void)
@@ -280,14 +309,29 @@ void InstrumentValueData::_updateRanges(void)
 void InstrumentValueData::_updateColor(void)
 {
     QColor newColor;
+    const double factValue = _fact ? _fact->rawValue().toDouble() : qQNaN();
+    const RangeSet* activeRangeSetToUse = &_range;
 
-    int rangeIndex = -1;
+    if (_rangeType == ColorRange) {
+        if (_individualFwMrRanges && _activeVehicle) {
+            const bool isVtol = _activeVehicle->vtol();
+            const bool isVtolInFwdFlight = isVtol && _activeVehicle->vtolInFwdFlight();
+            const bool isConsideredFixedWing = _activeVehicle->fixedWing() || (isVtol && isVtolInFwdFlight);
+            const bool isConsideredMultiRotor = _activeVehicle->multiRotor() || (isVtol && !isVtolInFwdFlight);
 
-    if (_rangeType == ColorRange && _fact) {
-        rangeIndex =_currentRangeIndex(_fact->rawValue().toDouble());
-    }
-    if (rangeIndex != -1) {
-        newColor = _rangeColors[rangeIndex].value<QColor>();
+            if (isConsideredFixedWing) {
+                activeRangeSetToUse = &_fwRange;
+            } else if (isConsideredMultiRotor) {
+                activeRangeSetToUse = &_mrRange;
+            }
+        }
+
+        if (_fact && !qIsNaN(factValue)) {
+            const int rangeIndex = _currentRangeIndex(factValue, activeRangeSetToUse->values);
+            if (rangeIndex != -1 && rangeIndex < activeRangeSetToUse->colors.count()) {
+                newColor = activeRangeSetToUse->colors[rangeIndex].value<QColor>();
+            }
+        }
     }
 
     if (newColor != _currentColor) {
@@ -299,14 +343,29 @@ void InstrumentValueData::_updateColor(void)
 void InstrumentValueData::_updateOpacity(void)
 {
     double newOpacity = 1.0;
+    double factValue = _fact ? _fact->rawValue().toDouble() : qQNaN();
+    const RangeSet* activeRangeSetToUse = &_range;
 
-    int rangeIndex = -1;
+    if (_rangeType == OpacityRange) {
+        if (_individualFwMrRanges && _activeVehicle) {
+            const bool isVtol = _activeVehicle->vtol();
+            const bool isVtolInFwdFlight = isVtol && _activeVehicle->vtolInFwdFlight();
+            const bool isConsideredFixedWing = _activeVehicle->fixedWing() || (isVtol && isVtolInFwdFlight);
+            const bool isConsideredMultiRotor = _activeVehicle->multiRotor() || (isVtol && !isVtolInFwdFlight);
 
-    if (_rangeType == OpacityRange && _fact) {
-        rangeIndex =_currentRangeIndex(_fact->rawValue().toDouble());
-    }
-    if (rangeIndex != -1) {
-        newOpacity = _rangeOpacities[rangeIndex].toDouble();
+            if (isConsideredFixedWing) {
+                activeRangeSetToUse = &_fwRange;
+            } else if (isConsideredMultiRotor) {
+                activeRangeSetToUse = &_mrRange;
+            }
+        }
+
+        if (_fact && !qIsNaN(factValue)) {
+            const int rangeIndex = _currentRangeIndex(factValue, activeRangeSetToUse->values);
+            if (rangeIndex != -1 && rangeIndex < activeRangeSetToUse->opacities.count()) {
+                newOpacity = activeRangeSetToUse->opacities[rangeIndex].toDouble();
+            }
+        }
     }
 
     if (!QGC::fuzzyCompare(newOpacity, _currentOpacity)) {
@@ -318,14 +377,29 @@ void InstrumentValueData::_updateOpacity(void)
 void InstrumentValueData::_updateIcon(void)
 {
     QString newIcon;
+    double factValue = _fact ? _fact->rawValue().toDouble() : qQNaN();
+    const RangeSet* activeRangeSetToUse = &_range;
 
-    int rangeIndex = -1;
+    if (_rangeType == IconSelectRange) {
+        if (_individualFwMrRanges && _activeVehicle) {
+            const bool isVtol = _activeVehicle->vtol();
+            const bool isVtolInFwdFlight = isVtol && _activeVehicle->vtolInFwdFlight();
+            const bool isConsideredFixedWing = _activeVehicle->fixedWing() || (isVtol && isVtolInFwdFlight);
+            const bool isConsideredMultiRotor = _activeVehicle->multiRotor() || (isVtol && !isVtolInFwdFlight);
 
-    if (_rangeType == IconSelectRange && _fact) {
-        rangeIndex =_currentRangeIndex(_fact->rawValue().toDouble());
-    }
-    if (rangeIndex != -1) {
-        newIcon = _rangeIcons[rangeIndex].toString();
+            if (isConsideredFixedWing) {
+                activeRangeSetToUse = &_fwRange;
+            } else if (isConsideredMultiRotor) {
+                activeRangeSetToUse = &_mrRange;
+            }
+        }
+
+        if (_fact && !qIsNaN(factValue)) {
+            const int rangeIndex = _currentRangeIndex(factValue, activeRangeSetToUse->values);
+            if (rangeIndex != -1 && rangeIndex < activeRangeSetToUse->icons.count()) {
+                newIcon = activeRangeSetToUse->icons[rangeIndex].toString();
+            }
+        }
     }
 
     if (newIcon != _currentIcon) {
@@ -334,17 +408,17 @@ void InstrumentValueData::_updateIcon(void)
     }
 }
 
-int InstrumentValueData::_currentRangeIndex(const QVariant& value)
+int InstrumentValueData::_currentRangeIndex(const QVariant& value, const QVariantList& rangeValuesToUse)
 {
-    if (qIsNaN(value.toDouble())) {
+    if (qIsNaN(value.toDouble()) || rangeValuesToUse.isEmpty()) {
         return 0;
     }
-    for (int i=0; i<_rangeValues.count(); i++) {
-        if (value.toDouble() <= _rangeValues[i].toDouble()) {
+    for (int i = 0; i < rangeValuesToUse.count(); i++) {
+        if (value.toDouble() <= rangeValuesToUse[i].toDouble()) {
             return i;
         }
     }
-    return _rangeValues.count();
+    return rangeValuesToUse.count();
 }
 
 QStringList InstrumentValueData::factGroupNames(void) const
@@ -378,4 +452,92 @@ QStringList InstrumentValueData::factValueNames(void) const
     }
 
     return valueNames;
+}
+
+void InstrumentValueData::setFwRangeValues(const QVariantList& fwRangeValues)
+{
+    if (_fwRange.values != fwRangeValues) {
+        _fwRange.values = fwRangeValues;
+        emit fwRangeValuesChanged(_fwRange.values);
+    }
+}
+
+void InstrumentValueData::setFwRangeColors(const QVariantList& fwRangeColors)
+{
+    if (_fwRange.colors != fwRangeColors) {
+        _fwRange.colors = fwRangeColors;
+        emit fwRangeColorsChanged(_fwRange.colors);
+    }
+}
+
+void InstrumentValueData::setFwRangeIcons(const QVariantList& fwRangeIcons)
+{
+    if (_fwRange.icons != fwRangeIcons) {
+        _fwRange.icons = fwRangeIcons;
+        emit fwRangeIconsChanged(_fwRange.icons);
+    }
+}
+
+void InstrumentValueData::setFwRangeOpacities(const QVariantList& fwRangeOpacities)
+{
+    if (_fwRange.opacities != fwRangeOpacities) {
+        _fwRange.opacities = fwRangeOpacities;
+        emit fwRangeOpacitiesChanged(_fwRange.opacities);
+    }
+}
+
+void InstrumentValueData::setMrRangeValues(const QVariantList& mrRangeValues)
+{
+    if (_mrRange.values != mrRangeValues) {
+        _mrRange.values = mrRangeValues;
+        emit mrRangeValuesChanged(_mrRange.values);
+    }
+}
+
+void InstrumentValueData::setMrRangeColors(const QVariantList& mrRangeColors)
+{
+    if (_mrRange.colors != mrRangeColors) {
+        _mrRange.colors = mrRangeColors;
+        emit mrRangeColorsChanged(_mrRange.colors);
+    }
+}
+
+void InstrumentValueData::setMrRangeIcons(const QVariantList& mrRangeIcons)
+{
+    if (_mrRange.icons != mrRangeIcons) {
+        _mrRange.icons = mrRangeIcons;
+        emit mrRangeIconsChanged(_mrRange.icons);
+    }
+}
+
+void InstrumentValueData::setMrRangeOpacities(const QVariantList& mrRangeOpacities)
+{
+    if (_mrRange.opacities != mrRangeOpacities) {
+        _mrRange.opacities = mrRangeOpacities;
+        emit mrRangeOpacitiesChanged(_mrRange.opacities);
+    }
+}
+
+void InstrumentValueData::_emitRangeSignals(const InstrumentValueData::RangeSet& rangeSet, InstrumentValueData::RangeSignalType signalType)
+{
+    switch (signalType) {
+    case NormalRange:
+        emit rangeValuesChanged(rangeSet.values);
+        emit rangeColorsChanged(rangeSet.colors);
+        emit rangeOpacitiesChanged(rangeSet.opacities);
+        emit rangeIconsChanged(rangeSet.icons);
+        break;
+    case FwRange:
+        emit fwRangeValuesChanged(rangeSet.values);
+        emit fwRangeColorsChanged(rangeSet.colors);
+        emit fwRangeOpacitiesChanged(rangeSet.opacities);
+        emit fwRangeIconsChanged(rangeSet.icons);
+        break;
+    case MrRange:
+        emit mrRangeValuesChanged(rangeSet.values);
+        emit mrRangeColorsChanged(rangeSet.colors);
+        emit mrRangeOpacitiesChanged(rangeSet.opacities);
+        emit mrRangeIconsChanged(rangeSet.icons);
+        break;
+    }
 }

--- a/src/QmlControls/InstrumentValueData.h
+++ b/src/QmlControls/InstrumentValueData.h
@@ -50,6 +50,17 @@ public:
     Q_PROPERTY(QColor               currentColor        MEMBER _currentColor                                NOTIFY currentColorChanged)
     Q_PROPERTY(double               currentOpacity      MEMBER _currentOpacity                              NOTIFY currentOpacityChanged)
     Q_PROPERTY(QString              currentIcon         MEMBER _currentIcon                                 NOTIFY currentIconChanged)
+    Q_PROPERTY(bool                 individualFwMrRanges READ individualFwMrRanges WRITE setIndividualFwMrRanges NOTIFY individualFwMrRangesChanged)
+
+    Q_PROPERTY(QVariantList         fwRangeValues       READ    fwRangeValues       WRITE setFwRangeValues    NOTIFY fwRangeValuesChanged)
+    Q_PROPERTY(QVariantList         fwRangeColors       READ    fwRangeColors       WRITE setFwRangeColors    NOTIFY fwRangeColorsChanged)
+    Q_PROPERTY(QVariantList         fwRangeIcons        READ    fwRangeIcons        WRITE setFwRangeIcons     NOTIFY fwRangeIconsChanged)
+    Q_PROPERTY(QVariantList         fwRangeOpacities    READ    fwRangeOpacities    WRITE setFwRangeOpacities NOTIFY fwRangeOpacitiesChanged)
+
+    Q_PROPERTY(QVariantList         mrRangeValues       READ    mrRangeValues       WRITE setMrRangeValues    NOTIFY mrRangeValuesChanged)
+    Q_PROPERTY(QVariantList         mrRangeColors       READ    mrRangeColors       WRITE setMrRangeColors    NOTIFY mrRangeColorsChanged)
+    Q_PROPERTY(QVariantList         mrRangeIcons        READ    mrRangeIcons        WRITE setMrRangeIcons     NOTIFY mrRangeIconsChanged)
+    Q_PROPERTY(QVariantList         mrRangeOpacities    READ    mrRangeOpacities    WRITE setMrRangeOpacities NOTIFY mrRangeOpacitiesChanged)
 
     Q_INVOKABLE void    setFact         (const QString& factGroupName, const QString& factName);
     Q_INVOKABLE void    clearFact       (void);
@@ -67,10 +78,22 @@ public:
     bool            showUnits               (void) const { return _showUnits; }
     QString         icon                    (void) const { return _icon; }
     RangeType       rangeType               (void) const { return _rangeType; }
-    QVariantList    rangeValues             (void) const { return _rangeValues; }
-    QVariantList    rangeColors             (void) const { return _rangeColors; }
-    QVariantList    rangeIcons              (void) const { return _rangeIcons; }
-    QVariantList    rangeOpacities          (void) const { return _rangeOpacities; }
+    QVariantList    rangeValues             (void) const { return _range.values; }
+    QVariantList    rangeColors             (void) const { return _range.colors; }
+    QVariantList    rangeIcons              (void) const { return _range.icons; }
+    QVariantList    rangeOpacities          (void) const { return _range.opacities; }
+    bool            individualFwMrRanges    (void) const { return _individualFwMrRanges; }
+
+    QVariantList    fwRangeValues           (void) const { return _fwRange.values; }
+    QVariantList    fwRangeColors           (void) const { return _fwRange.colors; }
+    QVariantList    fwRangeIcons            (void) const { return _fwRange.icons; }
+    QVariantList    fwRangeOpacities        (void) const { return _fwRange.opacities; }
+
+    QVariantList    mrRangeValues           (void) const { return _mrRange.values; }
+    QVariantList    mrRangeColors           (void) const { return _mrRange.colors; }
+    QVariantList    mrRangeIcons            (void) const { return _mrRange.icons; }
+    QVariantList    mrRangeOpacities        (void) const { return _mrRange.opacities; }
+
     void            setText                 (const QString& text);
     void            setShowUnits            (bool showUnits);
     void            setIcon                 (const QString& icon);
@@ -79,7 +102,17 @@ public:
     void            setRangeColors          (const QVariantList& rangeColors);
     void            setRangeIcons           (const QVariantList& rangeIcons);
     void            setRangeOpacities       (const QVariantList& rangeOpacities);
+    void            setIndividualFwMrRanges (bool individualFwMrRanges);
 
+    void            setFwRangeValues        (const QVariantList& fwRangeValues);
+    void            setFwRangeColors        (const QVariantList& fwRangeColors);
+    void            setFwRangeIcons         (const QVariantList& fwRangeIcons);
+    void            setFwRangeOpacities     (const QVariantList& fwRangeOpacities);
+
+    void            setMrRangeValues        (const QVariantList& mrRangeValues);
+    void            setMrRangeColors        (const QVariantList& mrRangeColors);
+    void            setMrRangeIcons         (const QVariantList& mrRangeIcons);
+    void            setMrRangeOpacities     (const QVariantList& mrRangeOpacities);
 
     static const char*  vehicleFactGroupName;
 
@@ -100,6 +133,19 @@ signals:
     void currentColorChanged    (const QColor& currentColor);
     void currentOpacityChanged  (double currentOpacity);
     void currentIconChanged     (const QString& currentIcon);
+    void individualFwMrRangesChanged (bool individualFwMrRanges);
+
+    // Signals for FW ranges
+    void fwRangeValuesChanged   (const QVariantList& fwRangeValues);
+    void fwRangeColorsChanged   (const QVariantList& fwRangeColors);
+    void fwRangeIconsChanged    (const QVariantList& fwRangeIcons);
+    void fwRangeOpacitiesChanged(const QVariantList& fwRangeOpacities);
+
+    // Signals for MR ranges
+    void mrRangeValuesChanged   (const QVariantList& mrRangeValues);
+    void mrRangeColorsChanged   (const QVariantList& mrRangeColors);
+    void mrRangeIconsChanged    (const QVariantList& mrRangeIcons);
+    void mrRangeOpacitiesChanged(const QVariantList& mrRangeOpacities);
 
 private slots:
     void _resetRangeInfo        (void);
@@ -108,11 +154,30 @@ private slots:
     void _lookForMissingFact    (void);
 
 private:
-    int  _currentRangeIndex     (const QVariant& value);
+    struct RangeSet {
+        QVariantList    values;
+        QVariantList    colors;
+        QVariantList    icons;
+        QVariantList    opacities;
+    };
+
+    // Enum to specify the type of range for signal emission
+    enum RangeSignalType {
+        NormalRange,
+        FwRange,
+        MrRange
+    };
+
+    void _emitRangeSignals(const RangeSet& rangeSet, RangeSignalType signalType);
+
+    int  _currentRangeIndex     (const QVariant& value, const QVariantList& rangeValuesToUse);
     void _updateColor           (void);
     void _updateIcon            (void);
     void _updateOpacity         (void);
     void _setFactWorker         (void);
+    void _resetRangeInfoCommon  (RangeSet& rangeSet);
+    void _addRangeValueCommon   (RangeSet& rangeSet);
+    void _removeRangeValueCommon(int index, RangeSet& rangeSet);
 
     FactValueGrid*          _factValueGrid =        nullptr;
     Vehicle*                _activeVehicle =        nullptr;
@@ -136,10 +201,10 @@ private:
     // a specific value for each section of the range. There should be _rangeValues.count() + 2
     // semantic values in the apppropriate list.
     RangeType           _rangeType =        NoRangeInfo;
-    QVariantList        _rangeValues;                       ///< double values which indicate range setpoints
-    QVariantList        _rangeColors;                       ///< QColor
-    QVariantList        _rangeIcons;                        ///< QString resource name
-    QVariantList        _rangeOpacities;                    /// double opacity value
+    RangeSet            _range;
+    RangeSet            _fwRange;
+    RangeSet            _mrRange;
+    bool                _individualFwMrRanges = false;
 
     // These are user facing string for the various enums.
     static const QStringList _rangeTypeNames;


### PR DESCRIPTION
Remove the posibility to edit limit values from QGC. This is because we want this to be locked, and configured from multi-command


