### PR TITLE
feat: prod and staging versions

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -238,6 +238,8 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     bool fClearCache = false;           // Clear parameter/airframe caches
     bool logging = false;               // Turn on logging
     QString loggingOptions;
+    bool modeSpecified = false;         // Mode option was specified
+    QString modeOption;                 // Application mode (prod/test)
 
     CmdLineOpt_t rgCmdLineOptions[] = {
         { "--clear-settings",   &fClearSettingsOptions, nullptr },
@@ -245,10 +247,24 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
         { "--logging",          &logging,               &loggingOptions },
         { "--fake-mobile",      &_fakeMobile,           nullptr },
         { "--log-output",       &_logOutput,            nullptr },
+        { "--mode",             &modeSpecified,         &modeOption },
         // Add additional command line option flags here
     };
 
     ParseCmdLineOptions(argc, argv, rgCmdLineOptions, sizeof(rgCmdLineOptions)/sizeof(rgCmdLineOptions[0]), false);
+
+    // Process mode option
+    if (modeSpecified && !modeOption.isEmpty()) {
+        if (modeOption.compare("prod", Qt::CaseInsensitive) == 0) {
+            _productionMode = true;
+            qDebug() << "Running in PRODUCTION mode - some features will be disabled";
+        } else if (modeOption.compare("test", Qt::CaseInsensitive) == 0) {
+            _productionMode = false;
+            qDebug() << "Running in TEST mode - all features enabled";
+        } else {
+            qWarning() << "Invalid mode option:" << modeOption << "- Valid options are prod or test. Defaulting to test mode.";
+        }
+    }
 
     // Set up timer for delayed missing fact display
     _missingParamsDelayedDisplayTimer.setSingleShot(true);

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -79,6 +79,9 @@ public:
     /// @return true: Fake ui into showing mobile interface
     bool fakeMobile(void) const { return _fakeMobile; }
 
+    /// @return true: Application is running in production mode (some features disabled)
+    bool isProductionMode(void) const { return _productionMode; }
+
     // Still working on getting rid of this and using dependency injection instead for everything
     QGCToolbox* toolbox(void) { return _toolbox; }
 
@@ -198,6 +201,7 @@ private:
     QQmlApplicationEngine* _qmlAppEngine        = nullptr;
     bool                _logOutput              = false;    ///< true: Log Qt debug output to file
     bool				_fakeMobile             = false;    ///< true: Fake ui into displaying mobile interface
+    bool                _productionMode         = false;    ///< true: Application is running in production mode (some features disabled)
     bool                _settingsUpgraded       = false;    ///< true: Settings format has been upgrade to new version
     int                 _majorVersion           = 0;
     int                 _minorVersion           = 0;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -30,6 +30,9 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
     setParent(nullptr);
 
+    // Initialize production mode from application
+    _isProductionMode = app->isProductionMode();
+
     // Load last coordinates and zoom from config file
     QSettings settings;
     settings.beginGroup(_flightMapPositionSettingsGroup);

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -93,6 +93,7 @@ public:
 
     Q_PROPERTY(QString qgcVersion       READ qgcVersion         CONSTANT)
     Q_PROPERTY(bool    skipSetupPage    READ skipSetupPage      WRITE setSkipSetupPage NOTIFY skipSetupPageChanged)
+    Q_PROPERTY(bool    isProductionMode READ isProductionMode   CONSTANT)
 
     Q_PROPERTY(qreal zOrderTopMost              READ zOrderTopMost              CONSTANT) ///< z order for top most items, toolbar, main window sub view
     Q_PROPERTY(qreal zOrderWidgets              READ zOrderWidgets              CONSTANT) ///< z order value to widgets, for example: zoom controls, hud widgetss
@@ -213,6 +214,8 @@ public:
     bool    apmFirmwareSupported    ();
     bool    skipSetupPage           () const{ return _skipSetupPage; }
     void    setSkipSetupPage        (bool skip);
+    
+    bool    isProductionMode        () const{ return _isProductionMode; }
 
     void    setIsVersionCheckEnabled    (bool enable);
     void    setMavlinkSystemID          (int  id);
@@ -266,6 +269,7 @@ private:
 #endif
 
     bool                    _skipSetupPage          = false;
+    bool                    _isProductionMode       = false;
     QStringList             _altitudeModeEnumString;
 
     static const char* _flightMapPositionSettingsGroup;

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -363,56 +363,85 @@ ApplicationWindow {
                     Layout.margins: _margins
                     spacing:        ScreenTools.defaultFontPixelWidth
 
-                    SubMenuButton {
-                        id:                 setupButton
-                        height:             _toolButtonHeight
-                        Layout.fillWidth:   true
-                        text:               qsTr("Vehicle Setup")
-                        imageColor:         qgcPal.text
-                        imageResource:      "/qmlimages/Gears.svg"
-                        onClicked: {
-                            if (!mainWindow.preventViewSwitch()) {
-                                toolSelectDialog.hideDialog()
-                                mainWindow.showSetupTool()
-                            }
+                    // Production mode message
+                    ColumnLayout {
+                        visible: QGroundControl.isProductionMode
+                        Layout.fillWidth: true
+                        spacing: ScreenTools.defaultFontPixelWidth
+
+                        QGCLabel {
+                            text: qsTr("Settings can not be changed in production mode")
+                            font.pointSize: ScreenTools.largeFontPointSize
+                            Layout.alignment: Qt.AlignHCenter
+                            Layout.fillWidth: true
+                            horizontalAlignment: Text.AlignHCenter
+                        }
+
+                        QGCLabel {
+                            text: qsTr("Start QGC in TEST mode to edit settings")
+                            font.pointSize: ScreenTools.defaultFontPointSize
+                            Layout.alignment: Qt.AlignHCenter
+                            Layout.fillWidth: true
+                            horizontalAlignment: Text.AlignHCenter
                         }
                     }
 
-                    SubMenuButton {
-                        id:                 analyzeButton
-                        height:             _toolButtonHeight
-                        Layout.fillWidth:   true
-                        text:               qsTr("Analyze Tools")
-                        imageResource:      "/qmlimages/Analyze.svg"
-                        imageColor:         qgcPal.text
-                        visible:            QGroundControl.corePlugin.showAdvancedUI
-                        onClicked: {
-                            if (!mainWindow.preventViewSwitch()) {
-                                toolSelectDialog.hideDialog()
-                                mainWindow.showAnalyzeTool()
+                    // Normal tool selection (only visible in TEST mode)
+                    ColumnLayout {
+                        visible: !QGroundControl.isProductionMode
+                        Layout.fillWidth: true
+                        spacing: ScreenTools.defaultFontPixelWidth
+
+                        SubMenuButton {
+                            id:                 setupButton
+                            height:             _toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Vehicle Setup")
+                            imageColor:         qgcPal.text
+                            imageResource:      "/qmlimages/Gears.svg"
+                            onClicked: {
+                                if (!mainWindow.preventViewSwitch()) {
+                                    toolSelectDialog.hideDialog()
+                                    mainWindow.showSetupTool()
+                                }
                             }
                         }
-                    }
 
-                    SubMenuButton {
-                        id:                 settingsButton
-                        height:             _toolButtonHeight
-                        Layout.fillWidth:   true
-                        text:               qsTr("Application Settings")
-                        imageResource:      "/res/QGCLogoFull"
-                        imageColor:         "transparent"
-                        visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
-                        onClicked: {
-                            if (!mainWindow.preventViewSwitch()) {
-                                toolSelectDialog.hideDialog()
-                                mainWindow.showSettingsTool()
+                        SubMenuButton {
+                            id:                 analyzeButton
+                            height:             _toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Analyze Tools")
+                            imageResource:      "/qmlimages/Analyze.svg"
+                            imageColor:         qgcPal.text
+                            visible:            QGroundControl.corePlugin.showAdvancedUI
+                            onClicked: {
+                                if (!mainWindow.preventViewSwitch()) {
+                                    toolSelectDialog.hideDialog()
+                                    mainWindow.showAnalyzeTool()
+                                }
+                            }
+                        }
+
+                        SubMenuButton {
+                            id:                 settingsButton
+                            height:             _toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Application Settings")
+                            imageResource:      "/res/QGCLogoFull"
+                            imageColor:         "transparent"
+                            visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
+                            onClicked: {
+                                if (!mainWindow.preventViewSwitch()) {
+                                    toolSelectDialog.hideDialog()
+                                    mainWindow.showSettingsTool()
+                                }
                             }
                         }
                     }
 
                     ColumnLayout {
-                        width:      innerLayout.width
-                        spacing:    0
+                        Layout.fillWidth: true
 
                         QGCLabel {
                             id:                     versionLabel


### PR DESCRIPTION
Allows starting QGroundControl with either PROD or TEST mode. PROD mode prevents users from changing settins. TEST is default. Needs [this](https://github.com/aviant-tech/multi-command/pull/41) Multi-command change to run

UI:
<img width="2533" height="1507" alt="image" src="https://github.com/user-attachments/assets/956ee005-dcd8-4abb-a91c-2d9e6453efd2" />
