### PR TITLE
chore: bump windows runner image

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on:  windows-2019
+    runs-on:  windows-2022
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
windows-2019 runner was deprecated, bump to 2022 to fix