### PR TITLE
ci: dont build new android versions

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -76,6 +76,8 @@ jobs:
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-35-ext14"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-35-ext15"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-36"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-36-ext19"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-36-ext18"
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir


### PR DESCRIPTION
When I pushed a docs PR, CI failed. It seems that the problem was some new android versions that werent set up correctly for build. I dont think we need those versions now. We can add them back later if we do. Fredrik previously fixed an android-35 issue similarly.

The future is a rebase on QGCv5 anyway.