### PR TITLE
feat: verbose conversion for old aviant rally point format

### DIFF
--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -28,6 +28,47 @@ QGC_LOGGING_CATEGORY(RallyPointControllerLog, "RallyPointControllerLog")
 const char* RallyPointController::_jsonFileTypeValue =  "RallyPoints";
 const char* RallyPointController::_jsonPointsKey =      "points";
 
+// Helper to convert legacy Aviant rally point arrays from
+// [lat, lon, alt, type] to standard [lat, lon, alt].
+// Returns true on success and fills convertedPointsValue, false on error
+// and sets errorString.
+static bool _convertLegacyAviantRallyPoints(const QJsonValue& pointsValue,
+                                            QJsonValue&       convertedPointsValue,
+                                            QString&          errorString)
+{
+    if (!pointsValue.isArray()) {
+        errorString = QString("value for coordinate array is not array");
+        return false;
+    }
+
+    QJsonArray rgJsonPoints = pointsValue.toArray();
+    QJsonArray convertedPointsArray;
+
+    for (int i = 0; i < rgJsonPoints.count(); ++i) {
+        const QJsonValue pointValue = rgJsonPoints[i];
+
+        if (!pointValue.isArray()) {
+            errorString = QString("value for coordinate is not array");
+            return false;
+        }
+
+        QJsonArray pointArray = pointValue.toArray();
+        if (pointArray.count() != 4) {
+            errorString = QString("legacy Aviant coordinate array must contain exactly 4 values");
+            return false;
+        }
+
+        QJsonArray convertedPointArray;
+        convertedPointArray.append(pointArray[0]);
+        convertedPointArray.append(pointArray[1]);
+        convertedPointArray.append(pointArray[2]);
+        convertedPointsArray.append(convertedPointArray);
+    }
+
+    convertedPointsValue = QJsonValue(convertedPointsArray);
+    return true;
+}
+
 RallyPointController::RallyPointController(PlanMasterController* masterController, QObject* parent)
     : PlanElementController (masterController, parent)
     , _managerVehicle               (masterController->managerVehicle())
@@ -102,13 +143,28 @@ bool RallyPointController::load(const QJsonObject& json, QString& errorString)
     QString errorStr;
     QString errorMessage = tr("Rally: %1");
 
-    if (json[JsonHelper::jsonVersionKey].toInt() != _jsonCurrentVersion) {
+    const int version = json[JsonHelper::jsonVersionKey].toInt();
+
+    if (version != _jsonCurrentVersion && version != _jsonLegacyAviantVersion) {
         errorString = tr("Rally Points supports version %1").arg(_jsonCurrentVersion);
         return false;
     }
 
     QList<QGeoCoordinate> rgPoints;
-    if (!JsonHelper::loadGeoCoordinateArray(json[_jsonPointsKey], true /* altitudeRequired */, rgPoints, errorStr)) {
+    QJsonValue pointsValue = json[_jsonPointsKey];
+
+    if (version == _jsonLegacyAviantVersion) {
+        QJsonValue convertedPointsValue;
+        QString convertError;
+        if (!_convertLegacyAviantRallyPoints(pointsValue, convertedPointsValue, convertError)) {
+            errorString = errorMessage.arg(convertError);
+            return false;
+        }
+        pointsValue = convertedPointsValue;
+        qgcApp()->showAppMessage(QString("Legacy Aviant MR/FW rally points have been converted to standard rally points"));
+    }
+
+    if (!JsonHelper::loadGeoCoordinateArray(pointsValue, true /* altitudeRequired */, rgPoints, errorStr)) {
         errorString = errorMessage.arg(errorStr);
         return false;
     }

--- a/src/MissionManager/RallyPointController.h
+++ b/src/MissionManager/RallyPointController.h
@@ -83,6 +83,7 @@ private:
     double              _progressPct =          0;
 
     static const int    _jsonCurrentVersion = 2;
+    static const int    _jsonLegacyAviantVersion = 102;
     static const char*  _jsonFileTypeValue;
     static const char*  _jsonPointsKey;
 };


### PR DESCRIPTION
<img width="455" height="99" alt="image" src="https://github.com/user-attachments/assets/10abb98b-68c1-4e75-80f3-eb1d35e42f21" />

We want to be able to use missions that were generated with the old rally point format. However, since the mission is actually changed, a warning should be displayed in this case.

Deliberately avoided overriding `jsonHelper` like in https://github.com/aviant-tech/qgroundcontrol/pull/25/files in order to keep number of changes vs. upstream small. (Now that they are reverted anyway)