### PR TITLE
Disable unused workflows

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -22,6 +22,8 @@ env:
 
 jobs:
   build:
+    # Workflow disabled: Android release not used
+    if: ${{ false }}
     runs-on:  ubuntu-22.04
 
     strategy:

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -22,6 +22,8 @@ env:
 
 jobs:
   build:
+    # Workflow disabled: Windows release not used
+    if: ${{ false }}
     runs-on:  windows-2022
 
     steps:


### PR DESCRIPTION
We don't use the Android and Windows builds, so no need having them enabled and failing.