### PR TITLE
feat: use MAV_CMD_DO_FLIGHTTERMINATION on emergency stop

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2904,10 +2904,9 @@ void Vehicle::emergencyStop()
 {
     sendMavCommand(
                 _defaultComponentId,
-                MAV_CMD_COMPONENT_ARM_DISARM,
+                MAV_CMD_DO_FLIGHTTERMINATION,
                 true,        // show error if fails
-                0.0f,
-                21196.0f);  // Magic number for emergency stop
+                1.0f);       // Do the termination
 }
 
 void Vehicle::setCurrentMissionSequence(int seq)


### PR DESCRIPTION
This will ensure parachute deployment happens correctly. Working document: https://aviant.atlassian.net/wiki/x/AYC1f


TODO before merge:

- [x] Test on TEST01
- [x] Update auto ground test to match