### PR TITLE
Connect to ATS from AGC

### DIFF
--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -140,6 +140,11 @@ MavlinkConsoleController::_sendSerialData(QByteArray data, bool close)
         return;
     }
 
+    // Force v2 so SERIAL_CONTROL extension fields (target_system, target_component) are sent
+    mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(sharedLink->mavlinkChannel());
+    uint8_t savedFlags = mavlinkStatus->flags;
+    mavlinkStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+
     // Send maximum sized chunks until the complete buffer is transmitted
     while(data.size()) {
         QByteArray chunk{data.left(MAVLINK_MSG_SERIAL_CONTROL_FIELD_DATA_LEN)};
@@ -165,6 +170,8 @@ MavlinkConsoleController::_sendSerialData(QByteArray data, bool close)
         _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
         data.remove(0, chunk.size());
     }
+
+    mavlinkStatus->flags = savedFlags;
 }
 
 bool

--- a/src/FactSystem/FactControls/FactPanelController.cc
+++ b/src/FactSystem/FactControls/FactPanelController.cc
@@ -83,7 +83,7 @@ void FactPanelController::getMissingParameters(QStringList rgNames)
 {
     for (const QString& name: rgNames) {
         _missingParameterWaitList.append(name);
-        _vehicle->parameterManager()->refreshParameter(MAV_COMP_ID_AUTOPILOT1, name);
+        _vehicle->parameterManager()->refreshParameter(_vehicle->defaultComponentId(), name);
     }
 
     _missingParametersTimer.start();
@@ -93,7 +93,7 @@ void FactPanelController::_checkForMissingParameters(void)
 {
     QStringList waitList = _missingParameterWaitList;
     for (const QString& name: waitList) {
-        if (_vehicle->parameterManager()->parameterExists(MAV_COMP_ID_AUTOPILOT1, name)) {
+        if (_vehicle->parameterManager()->parameterExists(_vehicle->defaultComponentId(), name)) {
             _missingParameterWaitList.removeOne(name);
         }
     }

--- a/src/FactSystem/FactControls/FactPanelController.h
+++ b/src/FactSystem/FactControls/FactPanelController.h
@@ -35,7 +35,7 @@ public:
     Q_INVOKABLE bool    parameterExists     (int componentId, const QString& name);
 
     /// Queries the vehicle for parameters which were not available on initial download but should be available now.
-    /// Signals missingParametersAvailable when done. Only works for MAV_COMP_ID_AUTOPILOT1 parameters.
+    /// Signals missingParametersAvailable when done. Only works for default component id parameters.
     Q_INVOKABLE void    getMissingParameters(QStringList rgNames);
 
 signals:

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -848,7 +848,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, QVarian
         const ParamTypeVal&             paramTypeVal    = cacheMap[name];
         const FactMetaData::ValueType_t fact_type       = static_cast<FactMetaData::ValueType_t>(paramTypeVal.first);
 
-        if (_vehicle->compInfoManager()->compInfoParam(MAV_COMP_ID_AUTOPILOT1)->factMetaDataForName(name, fact_type)->volatileValue()) {
+        if (_vehicle->compInfoManager()->compInfoParam(_vehicle->defaultComponentId())->factMetaDataForName(name, fact_type)->volatileValue()) {
             // Does not take part in CRC
             qCDebug(ParameterManagerLog) << "Volatile parameter" << name;
         } else {
@@ -1304,7 +1304,7 @@ void ParameterManager::_loadOfflineEditingParams(void)
 
 void ParameterManager::resetAllParametersToDefaults()
 {
-    _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
+    _vehicle->sendMavCommand(_vehicle->defaultComponentId(),
                              MAV_CMD_PREFLIGHT_STORAGE,
                              true,  // showError
                              2,     // Reset params to default

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -286,7 +286,7 @@ void APMFirmwarePlugin::_handleIncomingHeartbeat(Vehicle* vehicle, mavlink_messa
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(message, &heartbeat);
 
-    if (message->compid == MAV_COMP_ID_AUTOPILOT1) {
+    if (message->compid == vehicle->defaultComponentId()) {
         // We pull Vehicle::flying state from HEARTBEAT on ArduPilot. This is a firmware specific test.
         if (vehicle->armed()) {
 
@@ -453,7 +453,7 @@ void APMFirmwarePlugin::initializeStreamRates(Vehicle* vehicle)
     // This can cause various features to not be available. So we request home position streaming ourselves.
     // The MAV_CMD_SET_MESSAGE_INTERVAL command is only supported on newer firmwares. So we set showError=false.
     // Which also means than on older firmwares you may be left with some missing features.
-    vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_SET_MESSAGE_INTERVAL, false /* showError */, MAVLINK_MSG_ID_HOME_POSITION, 1000000 /* 1 second interval in usec */);
+    vehicle->sendMavCommand(vehicle->defaultComponentId(), MAV_CMD_SET_MESSAGE_INTERVAL, false /* showError */, MAVLINK_MSG_ID_HOME_POSITION, 1000000 /* 1 second interval in usec */);
 
     instanceData->lastBatteryStatusTime = instanceData->lastHomePositionTime = QTime::currentTime();
 }

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -112,7 +112,7 @@ void PlanManager::_writeMissionCount(void)
                                             sharedLink->mavlinkChannel(),
                                             &message,
                                             _vehicle->id(),
-                                            MAV_COMP_ID_AUTOPILOT1,
+                                            _vehicle->defaultComponentId(),
                                             _writeMissionItems.count(),
                                             _planType,
                                             0);
@@ -159,7 +159,7 @@ void PlanManager::_requestList(void)
                                                    sharedLink->mavlinkChannel(),
                                                    &message,
                                                    _vehicle->id(),
-                                                   MAV_COMP_ID_AUTOPILOT1,
+                                                   _vehicle->defaultComponentId(),
                                                    _planType);
 
         _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), message);
@@ -302,7 +302,7 @@ void PlanManager::_readTransactionComplete(void)
                                           sharedLink->mavlinkChannel(),
                                           &message,
                                           _vehicle->id(),
-                                          MAV_COMP_ID_AUTOPILOT1,
+                                          _vehicle->defaultComponentId(),
                                           MAV_MISSION_ACCEPTED,
                                           _planType,
                                           0);
@@ -365,7 +365,7 @@ void PlanManager::_requestNextMissionItem(void)
                                                   sharedLink->mavlinkChannel(),
                                                   &message,
                                                   _vehicle->id(),
-                                                  MAV_COMP_ID_AUTOPILOT1,
+                                                  _vehicle->defaultComponentId(),
                                                   _itemIndicesToRead[0],
                                                   _planType);
         _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), message);
@@ -526,7 +526,7 @@ void PlanManager::_handleMissionRequest(const mavlink_message_t& message)
                                                sharedLink->mavlinkChannel(),
                                                &messageOut,
                                                _vehicle->id(),
-                                               MAV_COMP_ID_AUTOPILOT1,
+                                               _vehicle->defaultComponentId(),
                                                missionRequestSeq,
                                                item->frame(),
                                                item->command(),
@@ -877,7 +877,7 @@ void PlanManager::_removeAllWorker(void)
                                                 sharedLink->mavlinkChannel(),
                                                 &message,
                                                 _vehicle->id(),
-                                                MAV_COMP_ID_AUTOPILOT1,
+                                                _vehicle->defaultComponentId(),
                                                 _planType);
         _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), message);
     }

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -68,8 +68,8 @@ void ParameterEditorController::_buildListsForComponent(int compId)
 
 void ParameterEditorController::_buildLists(void)
 {
-    // Autopilot component should always be first list
-    _buildListsForComponent(MAV_COMP_ID_AUTOPILOT1);
+    // Target autopilot component should always be first list
+    _buildListsForComponent(_vehicle->defaultComponentId());
 
     // "Standard" category should always be first
     for (int i=0; i<_categories.count(); i++) {
@@ -95,7 +95,7 @@ void ParameterEditorController::_buildLists(void)
 
     // Now add other random components
     for (int compId: _parameterMgr->componentIds()) {
-        if (compId != MAV_COMP_ID_AUTOPILOT1) {
+        if (compId != _vehicle->defaultComponentId()) {
             _buildListsForComponent(compId);
         }
     }

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -181,6 +181,12 @@ void QGroundControlQmlGlobal::setMavlinkSystemID(int id)
     emit mavlinkSystemIDChanged(id);
 }
 
+void QGroundControlQmlGlobal::setMavlinkTargetComponentID(int id)
+{
+    qgcApp()->toolbox()->mavlinkProtocol()->setTargetComponentId(id);
+    emit mavlinkTargetComponentIDChanged(id);
+}
+
 bool QGroundControlQmlGlobal::singleFirmwareSupport(void)
 {
     return _firmwarePluginManager->supportedFirmwareClasses().count() == 1;

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -105,6 +105,7 @@ public:
     // MavLink Protocol
     Q_PROPERTY(bool     isVersionCheckEnabled   READ isVersionCheckEnabled      WRITE setIsVersionCheckEnabled      NOTIFY isVersionCheckEnabledChanged)
     Q_PROPERTY(int      mavlinkSystemID         READ mavlinkSystemID            WRITE setMavlinkSystemID            NOTIFY mavlinkSystemIDChanged)
+    Q_PROPERTY(int      mavlinkTargetComponentID READ mavlinkTargetComponentID  WRITE setMavlinkTargetComponentID   NOTIFY mavlinkTargetComponentIDChanged)
     Q_PROPERTY(bool     hasAPMSupport           READ hasAPMSupport              CONSTANT)
     Q_PROPERTY(bool     hasMAVLinkInspector     READ hasMAVLinkInspector        CONSTANT)
 
@@ -195,6 +196,7 @@ public:
 
     bool    isVersionCheckEnabled   () { return _toolbox->mavlinkProtocol()->versionCheckEnabled(); }
     int     mavlinkSystemID         () { return _toolbox->mavlinkProtocol()->getSystemId(); }
+    int     mavlinkTargetComponentID() { return _toolbox->mavlinkProtocol()->getTargetComponentId(); }
 #if defined(NO_ARDUPILOT_DIALECT)
     bool    hasAPMSupport           () { return false; }
 #else
@@ -216,6 +218,7 @@ public:
 
     void    setIsVersionCheckEnabled    (bool enable);
     void    setMavlinkSystemID          (int  id);
+    void    setMavlinkTargetComponentID (int  id);
     void    setFlightMapPosition        (QGeoCoordinate& coordinate);
     void    setFlightMapZoom            (double zoom);
 
@@ -238,6 +241,7 @@ signals:
     void isMultiplexingEnabledChanged   (bool enabled);
     void isVersionCheckEnabledChanged   (bool enabled);
     void mavlinkSystemIDChanged         (int id);
+    void mavlinkTargetComponentIDChanged(int id);
     void flightMapPositionChanged       (QGeoCoordinate flightMapPosition);
     void flightMapZoomChanged           (double flightMapZoom);
     void skipSetupPageChanged           ();

--- a/src/Vehicle/Actuators/ActuatorActions.cc
+++ b/src/Vehicle/Actuators/ActuatorActions.cc
@@ -61,7 +61,7 @@ void Action::sendMavlinkRequest()
     _vehicle->sendMavCommandWithHandler(
             ackHandlerEntry,                  // Ack callback
             this,                             // Ack callback data
-            MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
+            _vehicle->defaultComponentId(),    // the ID of the autopilot
             MAV_CMD_CONFIGURE_ACTUATOR,       // the mavlink command
             (int)_type,                       // action type
             0,                                // unused parameter

--- a/src/Vehicle/Actuators/ActuatorTesting.cc
+++ b/src/Vehicle/Actuators/ActuatorTesting.cc
@@ -193,7 +193,7 @@ void ActuatorTest::sendMavlinkRequest(int function, float value, float timeout)
     _vehicle->sendMavCommandWithHandler(
             ackHandlerEntry,                  // Ack callback
             this,                             // Ack callback data
-            MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
+            _vehicle->defaultComponentId(),    // the ID of the autopilot
             MAV_CMD_ACTUATOR_TEST,            // the mavlink command
             value,                            // value
             timeout,                          // timeout

--- a/src/Vehicle/Actuators/MotorAssignment.cc
+++ b/src/Vehicle/Actuators/MotorAssignment.cc
@@ -218,7 +218,7 @@ void MotorAssignment::sendMavlinkRequest(int function, float value)
     _vehicle->sendMavCommandWithHandler(
             ackHandlerEntry,                  // Ack callback
             this,                             // Ack callback data
-            MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
+            _vehicle->defaultComponentId(),    // the ID of the autopilot
             MAV_CMD_ACTUATOR_TEST,            // the mavlink command
             value,                            // value
             0.5f,                             // timeout

--- a/src/Vehicle/Autotune.cpp
+++ b/src/Vehicle/Autotune.cpp
@@ -165,7 +165,7 @@ void Autotune::sendMavlinkRequest()
     _vehicle->sendMavCommandWithHandler(
             ackHandler,                       // Ack callback
             this,                             // Ack callback data
-            MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
+            _vehicle->defaultComponentId(),    // the ID of the autopilot
             MAV_CMD_DO_AUTOTUNE_ENABLE,       // the mavlink command
             1,                                // request autotune
             0,                                // unused parameter

--- a/src/Vehicle/CompInfoParam.cc
+++ b/src/Vehicle/CompInfoParam.cc
@@ -131,7 +131,7 @@ FactMetaData* CompInfoParam::factMetaDataForName(const QString& name, FactMetaDa
                 if (i > 0) {
                     factMetaData->setGroup(name.left(i));
                 }
-                if (compId != MAV_COMP_ID_AUTOPILOT1) {
+                if (compId != vehicle->defaultComponentId()) {
                     factMetaData->setCategory(tr("Component %1").arg(compId));
                 }
             }
@@ -303,7 +303,7 @@ QObject* CompInfoParam::_getOpaqueParameterMetaData(void)
         qWarning() << "CompInfoParam::_getOpaqueParameterMetaData _noJsonMetadata == false";
     }
 
-    if (!_opaqueParameterMetaData && compId == MAV_COMP_ID_AUTOPILOT1) {
+    if (!_opaqueParameterMetaData && compId == vehicle->defaultComponentId()) {
         // Load best parameter meta data set
         int majorVersion, minorVersion;
         QString metaDataFile = _parameterMetaDataFile(vehicle, vehicle->firmwareType(), majorVersion, minorVersion);

--- a/src/Vehicle/ComponentInformationManager.cc
+++ b/src/Vehicle/ComponentInformationManager.cc
@@ -51,10 +51,11 @@ ComponentInformationManager::ComponentInformationManager(Vehicle* vehicle)
     , _requestTypeStateMachine  (this)
     , _fileCache(ComponentInformationCache::defaultInstance())
 {
-    _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_GENERAL]    = new CompInfoGeneral   (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
-    _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_PARAMETER]  = new CompInfoParam     (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
-    _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_EVENTS]     = new CompInfoEvents    (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
-    _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_ACTUATORS]  = new CompInfoActuators (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
+    uint8_t compId = _vehicle->defaultComponentId();
+    _compInfoMap[compId][COMP_METADATA_TYPE_GENERAL]    = new CompInfoGeneral   (compId, vehicle, this);
+    _compInfoMap[compId][COMP_METADATA_TYPE_PARAMETER]  = new CompInfoParam     (compId, vehicle, this);
+    _compInfoMap[compId][COMP_METADATA_TYPE_EVENTS]     = new CompInfoEvents    (compId, vehicle, this);
+    _compInfoMap[compId][COMP_METADATA_TYPE_ACTUATORS]  = new CompInfoActuators (compId, vehicle, this);
 }
 
 int ComponentInformationManager::stateCount(void) const
@@ -92,7 +93,7 @@ void ComponentInformationManager::requestAllComponentInformation(RequestAllCompl
 void ComponentInformationManager::_stateRequestCompInfoGeneral(StateMachine* stateMachine)
 {
     ComponentInformationManager* compMgr = static_cast<ComponentInformationManager*>(stateMachine);
-    compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_GENERAL]);
+    compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[compMgr->_vehicle->defaultComponentId()][COMP_METADATA_TYPE_GENERAL]);
 }
 
 void ComponentInformationManager::_stateRequestCompInfoGeneralComplete(StateMachine* stateMachine)
@@ -104,8 +105,9 @@ void ComponentInformationManager::_stateRequestCompInfoGeneralComplete(StateMach
 
 void ComponentInformationManager::_updateAllUri()
 {
-    CompInfoGeneral* general = qobject_cast<CompInfoGeneral*>(_compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_GENERAL]);
-    for (auto& compInfo : _compInfoMap[MAV_COMP_ID_AUTOPILOT1]) {
+    uint8_t compId = _vehicle->defaultComponentId();
+    CompInfoGeneral* general = qobject_cast<CompInfoGeneral*>(_compInfoMap[compId][COMP_METADATA_TYPE_GENERAL]);
+    for (auto& compInfo : _compInfoMap[compId]) {
         general->setUris(*compInfo);
     }
 }
@@ -120,7 +122,7 @@ void ComponentInformationManager::_stateRequestCompInfoParam(StateMachine* state
     ComponentInformationManager* compMgr = static_cast<ComponentInformationManager*>(stateMachine);
 
     if (compMgr->_isCompTypeSupported(COMP_METADATA_TYPE_PARAMETER)) {
-        compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_PARAMETER]);
+        compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[compMgr->_vehicle->defaultComponentId()][COMP_METADATA_TYPE_PARAMETER]);
     } else {
         qCDebug(ComponentInformationManagerLog) << "_stateRequestCompInfoParam skipping, not supported";
         compMgr->advance();
@@ -132,7 +134,7 @@ void ComponentInformationManager::_stateRequestCompInfoEvents(StateMachine* stat
     ComponentInformationManager* compMgr = static_cast<ComponentInformationManager*>(stateMachine);
 
     if (compMgr->_isCompTypeSupported(COMP_METADATA_TYPE_EVENTS)) {
-        compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_EVENTS]);
+        compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[compMgr->_vehicle->defaultComponentId()][COMP_METADATA_TYPE_EVENTS]);
     } else {
         qCDebug(ComponentInformationManagerLog) << "_stateRequestCompInfoEvents skipping, not supported";
         compMgr->advance();
@@ -144,7 +146,7 @@ void ComponentInformationManager::_stateRequestCompInfoActuators(StateMachine* s
     ComponentInformationManager* compMgr = static_cast<ComponentInformationManager*>(stateMachine);
 
     if (compMgr->_isCompTypeSupported(COMP_METADATA_TYPE_ACTUATORS)) {
-        compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_ACTUATORS]);
+        compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[compMgr->_vehicle->defaultComponentId()][COMP_METADATA_TYPE_ACTUATORS]);
     } else {
         qCDebug(ComponentInformationManagerLog) << "_stateRequestCompInfoActuators skipping, not supported";
         compMgr->advance();
@@ -161,7 +163,7 @@ void ComponentInformationManager::_stateRequestAllCompInfoComplete(StateMachine*
 
 bool ComponentInformationManager::_isCompTypeSupported(COMP_METADATA_TYPE type)
 {
-    return qobject_cast<CompInfoGeneral*>(_compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_GENERAL])->isMetaDataTypeSupported(type);
+    return qobject_cast<CompInfoGeneral*>(_compInfoMap[_vehicle->defaultComponentId()][COMP_METADATA_TYPE_GENERAL])->isMetaDataTypeSupported(type);
 }
 
 CompInfoParam* ComponentInformationManager::compInfoParam(uint8_t compId)
@@ -280,7 +282,7 @@ void RequestMetaDataTypeStateMachine::_stateRequestCompInfo(StateMachine* stateM
             vehicle->requestMessage(
                         _requestMessageResultHandler,
                         stateMachine,
-                        MAV_COMP_ID_AUTOPILOT1,
+                        vehicle->defaultComponentId(),
                         MAVLINK_MSG_ID_COMPONENT_INFORMATION);
         }
     }

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -24,6 +24,7 @@ const char* FTPManager::mavlinkFTPScheme = "mftp";
 FTPManager::FTPManager(Vehicle* vehicle)
     : QObject   (vehicle)
     , _vehicle  (vehicle)
+    , _ftpCompId(vehicle->defaultComponentId())
 {
     _ackOrNakTimeoutTimer.setSingleShot(true);
     // Mock link responds immediately if at all, speed up unit tests with faster timoue
@@ -620,7 +621,7 @@ void FTPManager::_sendRequestExpectAck(MavlinkFTP::Request* request)
 bool FTPManager::_parseURI(const QString& uri, QString& parsedURI, uint8_t& compId)
 {
     parsedURI   = uri;
-    compId      = MAV_COMP_ID_AUTOPILOT1;
+    compId      = _vehicle->defaultComponentId();
 
     // Pull scheme off the front if there
     QString ftpPrefix(QStringLiteral("%1://").arg(mavlinkFTPScheme));

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -33,7 +33,7 @@ public:
 
 	/// Downloads the specified file.
     ///     @param fromURI  File to download from vehicle, fully qualified path. May be in the format "mftp://[;comp=<id>]..." where the component id is specified.
-    ///                     If component id is not specified MAV_COMP_ID_AUTOPILOT1 is used.
+    ///                     If component id is not specified the vehicle's default component id is used.
     ///     @param toDir    Local directory to download file to
     /// @return true: download has started, false: error, no download
     /// Signals downloadComplete, commandError, commandProgress

--- a/src/Vehicle/HealthAndArmingCheckReport.cc
+++ b/src/Vehicle/HealthAndArmingCheckReport.cc
@@ -8,7 +8,6 @@
  ****************************************************************************/
 
 #include "HealthAndArmingCheckReport.h"
-#include "QGCMAVLink.h"
 
 #include <libevents/libs/cpp/generated/events_generated.h>
 
@@ -35,10 +34,6 @@ HealthAndArmingCheckReport::~HealthAndArmingCheckReport()
 void HealthAndArmingCheckReport::update(uint8_t compid, const events::HealthAndArmingChecks::Results& results,
         int flightModeGroup)
 {
-    if (compid != MAV_COMP_ID_AUTOPILOT1) {
-        // only autopilot supported atm
-        return;
-    }
     if (flightModeGroup == -1) {
         qWarning() << "Flight mode group not set";
         return;

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -108,7 +108,7 @@ void InitialConnectStateMachine::_stateRequestAutopilotVersion(StateMachine* sta
             qCDebug(InitialConnectStateMachineLog) << "Sending REQUEST_MESSAGE:AUTOPILOT_VERSION";
             vehicle->requestMessage(_autopilotVersionRequestMessageHandler,
                                     connectMachine,
-                                    MAV_COMP_ID_AUTOPILOT1,
+                                    vehicle->defaultComponentId(),
                                     MAVLINK_MSG_ID_AUTOPILOT_VERSION);
         }
     }
@@ -220,7 +220,7 @@ void InitialConnectStateMachine::_stateRequestProtocolVersion(StateMachine* stat
             qCDebug(InitialConnectStateMachineLog) << "Sending REQUEST_MESSAGE:PROTOCOL_VERSION";
             vehicle->requestMessage(_protocolVersionRequestMessageHandler,
                                     connectMachine,
-                                    MAV_COMP_ID_AUTOPILOT1,
+                                    vehicle->defaultComponentId(),
                                     MAVLINK_MSG_ID_AUTOPILOT_VERSION);
         }
     }

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -77,14 +77,16 @@ void MultiVehicleManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicle
         vehicleType = 0;
     }
 
-    if (componentId != MAV_COMP_ID_AUTOPILOT1) {
+    int targetCompId = _mavlinkProtocol->getTargetComponentId();
+    if (componentId != targetCompId) {
         // Special case for PX4 Flow
         if (vehicleId != 81 || componentId != 50) {
-            // Don't create vehicles for components other than the autopilot
-            qCDebug(MultiVehicleManagerLog()) << "Ignoring heartbeat from unknown component port:vehicleId:componentId:fwType:vehicleType"
+            // Don't create vehicles for components other than the target
+            qCDebug(MultiVehicleManagerLog()) << "Ignoring heartbeat from non-target component port:vehicleId:componentId:targetCompId:fwType:vehicleType"
                                               << link->linkConfiguration()->name()
                                               << vehicleId
                                               << componentId
+                                              << targetCompId
                                               << vehicleFirmwareType
                                               << vehicleType;
             return;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1733,12 +1733,18 @@ EventHandler& Vehicle::_eventHandler(uint8_t compid)
 
         // connect health and arming check updates
         connect(eventHandler.data(), &EventHandler::healthAndArmingChecksUpdated, this, [compid, this]() {
+            if (compid != _defaultComponentId) {
+                return;
+            }
             // TODO: use user-intended mode instead of currently set mode
             const QSharedPointer<EventHandler>& eventHandler = _events[compid];
             _healthAndArmingCheckReport.update(compid, eventHandler->healthAndArmingCheckResults(),
                     eventHandler->getModeGroup(_custom_mode));
         });
         connect(this, &Vehicle::flightModeChanged, this, [compid, this]() {
+            if (compid != _defaultComponentId) {
+                return;
+            }
             const QSharedPointer<EventHandler>& eventHandler = _events[compid];
             if (eventHandler->healthAndArmingCheckResultsValid()) {
                 _healthAndArmingCheckReport.update(compid, eventHandler->healthAndArmingCheckResults(),
@@ -4144,7 +4150,7 @@ void Vehicle::sendParamMapRC(const QString& paramName, double scale, double cent
                                        sharedLink->mavlinkChannel(),
                                        &message,
                                        _id,
-                                       MAV_COMP_ID_AUTOPILOT1,
+                                       _defaultComponentId,
                                        param_id_cstr,
                                        -1,                                                  // parameter name specified as string in previous argument
                                        static_cast<uint8_t>(tuningID),
@@ -4172,7 +4178,7 @@ void Vehicle::clearAllParamMapRC(void)
                                            sharedLink->mavlinkChannel(),
                                            &message,
                                            _id,
-                                           MAV_COMP_ID_AUTOPILOT1,
+                                           _defaultComponentId,
                                            param_id_cstr,
                                            -2,                                                  // Disable map for specified tuning id
                                            i,                                                   // tuning id

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -306,7 +306,7 @@ bool VehicleLinkManager::_updatePrimaryLink(void)
     } else {
         if (bestActivePrimaryLink != primaryLink) {
             if (primaryLink && primaryLink->linkConfiguration()->isHighLatency()) {
-                _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
+                _vehicle->sendMavCommand(_vehicle->defaultComponentId(),
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
                                0); // Stop transmission on this link
@@ -316,7 +316,7 @@ bool VehicleLinkManager::_updatePrimaryLink(void)
             emit primaryLinkChanged();
 
             if (bestActivePrimaryLink && bestActivePrimaryLink->linkConfiguration()->isHighLatency()) {
-                _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
+                _vehicle->sendMavCommand(_vehicle->defaultComponentId(),
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
                                1); // Start transmission on this link

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -50,6 +50,7 @@ MAVLinkProtocol::MAVLinkProtocol(QGCApplication* app, QGCToolbox* toolbox)
     , _status({})
     , versionMismatchIgnore(false)
     , systemId(255)
+    , targetComponentId(MAV_COMP_ID_AUTOPILOT1)
     , _current_version(100)
     , _radio_version_mismatch_count(0)
     , _logSuspendError(false)
@@ -128,6 +129,12 @@ void MAVLinkProtocol::loadSettings()
     {
         systemId = temp;
     }
+
+    // Load target component id
+    int tempComp = settings.value("TARGET_COMPONENT_ID", targetComponentId).toInt();
+    if (tempComp > 0 && tempComp < 256) {
+        targetComponentId = tempComp;
+    }
 }
 
 void MAVLinkProtocol::storeSettings()
@@ -137,7 +144,7 @@ void MAVLinkProtocol::storeSettings()
     settings.beginGroup("QGC_MAVLINK_PROTOCOL");
     settings.setValue("VERSION_CHECK_ENABLED", m_enable_version_check);
     settings.setValue("GCS_SYSTEM_ID", systemId);
-    // Parameter interface settings
+    settings.setValue("TARGET_COMPONENT_ID", targetComponentId);
 }
 
 void MAVLinkProtocol::resetMetadataForLink(LinkInterface *link)
@@ -392,6 +399,15 @@ int MAVLinkProtocol::getSystemId() const
 void MAVLinkProtocol::setSystemId(int id)
 {
     systemId = id;
+}
+
+void MAVLinkProtocol::setTargetComponentId(int id)
+{
+    if (id > 0 && id < 256) {
+        targetComponentId = id;
+        storeSettings();
+        emit targetComponentIdChanged(id);
+    }
 }
 
 /** @return Component id of this application */

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -50,6 +50,8 @@ public:
     int getSystemId() const;
     /** @brief Get the component id of this application */
     int getComponentId();
+    /** @brief Get the target component id for the vehicle */
+    int getTargetComponentId() const { return targetComponentId; }
 
     /** @brief Get protocol version check state */
     bool versionCheckEnabled() const {
@@ -87,6 +89,9 @@ public slots:
     /** @brief Set the system id of this application */
     void setSystemId(int id);
 
+    /** @brief Set the target component id for the vehicle */
+    void setTargetComponentId(int id);
+
     /** @brief Enable / disable version check */
     void enableVersionCheck(bool enabled);
 
@@ -114,6 +119,7 @@ protected:
 
     bool        versionMismatchIgnore;
     int         systemId;
+    int         targetComponentId;
     unsigned    _current_version;
     int         _radio_version_mismatch_count;
 
@@ -129,6 +135,8 @@ signals:
     void protocolStatusMessage(const QString& title, const QString& message);
     /** @brief Emitted if a new system ID was set */
     void systemIdChanged(int systemId);
+    /** @brief Emitted if a new target component ID was set */
+    void targetComponentIdChanged(int componentId);
 
     void mavlinkMessageStatus(int uasId, uint64_t totalSent, uint64_t totalReceived, uint64_t totalLoss, float lossPercent);
 

--- a/src/ui/preferences/MavlinkSettings.qml
+++ b/src/ui/preferences/MavlinkSettings.qml
@@ -138,6 +138,28 @@ Rectangle {
                         }
                     }
 
+                    Row {
+                        spacing:    ScreenTools.defaultFontPixelWidth
+                        QGCLabel {
+                            width:              _labelWidth
+                            anchors.baseline:   compidField.baseline
+                            text:               qsTr("Target Component ID:")
+                        }
+                        QGCTextField {
+                            id:     compidField
+                            text:   QGroundControl.mavlinkTargetComponentID.toString()
+                            width:  _valueWidth
+                            inputMethodHints:       Qt.ImhFormattedNumbersOnly
+                            anchors.verticalCenter: parent.verticalCenter
+                            onEditingFinished: {
+                                QGroundControl.mavlinkTargetComponentID = parseInt(compidField.text)
+                            }
+                        }
+                    }
+                    QGCLabel {
+                        text:       qsTr("<i> Changing target component ID requires restart of application. </i>")
+                    }
+
                     QGCCheckBox {
                         text:       qsTr("Emit heartbeat")
                         checked:    QGroundControl.multiVehicleManager.gcsHeartBeatEnabled


### PR DESCRIPTION
Uses mavlink forwarding in PX4 to connect to ATS as if it were a drone

Must set target component ID a bunch of places, and force mavlink v2 for SERIAL_CONTROL Messages such that mavlink shell doesnt drop target sysid/compid
