### PR TITLE
Aviant/update ats indicator

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -100,6 +100,7 @@ const Fact& Fact::operator=(const Fact& other)
     _ignoreQGCRebootRequired    = other._ignoreQGCRebootRequired;
     _timeSinceLastUpdate        = other._timeSinceLastUpdate;
     _timedOut                   = other._timedOut;
+    _timeoutIndicatorColor      = other._timeoutIndicatorColor;
     if (_metaData && other._metaData) {
         *_metaData = *other._metaData;
     } else {
@@ -193,6 +194,16 @@ void Fact::setOverrideColor(const QColor& color)
 void Fact::unsetOverrideColor(void)
 {
     _overrideColorEnabled = false;
+}
+
+void Fact::setTimeoutIndicatorColor(const QColor& color)
+{
+    _timeoutIndicatorColor = color;
+}
+
+void Fact::unsetTimeoutIndicatorColor(void)
+{
+    _timeoutIndicatorColor = QColor();
 }
 
 void Fact::_containerSetRawValue(const QVariant& value)

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -151,6 +151,10 @@ public:
     void setEnumStringValue (const QString& value);
     void setOverrideColor   (const QColor& color);
     void unsetOverrideColor (void);
+
+    void            setTimeoutIndicatorColor(const QColor& color);
+    void            unsetTimeoutIndicatorColor(void);
+    QColor          timeoutIndicatorColor(void) const { return _timeoutIndicatorColor; }
     int  valueIndex         (const QString& value);
 
     // The following methods allow you to defer sending of the valueChanged signals in order to implement
@@ -226,6 +230,7 @@ protected:
     bool                        _ignoreQGCRebootRequired;
     bool                        _overrideColorEnabled;
     QColor                      _overrideColor;
+    QColor                      _timeoutIndicatorColor;
     QElapsedTimer               _timeSinceLastUpdate;
     bool                        _timedOut = false;
 };

--- a/src/QmlControls/InstrumentValueData.cc
+++ b/src/QmlControls/InstrumentValueData.cc
@@ -313,7 +313,8 @@ void InstrumentValueData::_updateColor(void)
     QColor newColor;
 
     if (_fact && _fact->timedOut()) {
-        newColor = QColor::fromRgb(255, 170, 0); // Orange
+        const QColor timeoutColor = _fact->timeoutIndicatorColor();
+        newColor = timeoutColor.isValid() ? timeoutColor : QColor::fromRgb(255, 170, 0); // Orange default
     } else if (_fact && _fact->overrideColorEnabled()) {
         newColor = _fact->overrideColor();
     } else {

--- a/src/Vehicle/AviantFactGroup.json
+++ b/src/Vehicle/AviantFactGroup.json
@@ -26,7 +26,7 @@
     "name":             "atsStatus",
     "shortDesc":        "ATS",
     "type":             "uint32",
-    "enumStrings":      "--,OK,WARN,FAIL",
+    "enumStrings":      "DEACT,OK,WARN,FAIL",
     "enumValues":       "0,1,2,3"
 },
 {

--- a/src/Vehicle/VehicleAviantFactGroup.cc
+++ b/src/Vehicle/VehicleAviantFactGroup.cc
@@ -187,14 +187,14 @@ void VehicleAviantFactGroup::handleAtsStatusMsg(Vehicle* vehicle, mavlink_messag
     mavlink_msg_aviant_ats_status_decode(&message, &atsStatus);
 
     // These should match atsStatus in AviantFactGroup.json
-    constexpr uint32_t VALUE_BLANK = 0;
+    constexpr uint32_t VALUE_DEACT = 0;
     constexpr uint32_t VALUE_OK = 1;
     constexpr uint32_t VALUE_WARN = 2;
     constexpr uint32_t VALUE_FAIL = 3;
 
     if (!atsStatus.ats_enabled) {
         _atsStatusFact.setOverrideColor(COLOR_UNKNOWN);
-        _atsStatusFact.setRawValue(VALUE_BLANK);
+        _atsStatusFact.setRawValue(VALUE_DEACT);
         return;
     }
     uint32_t ats_status_flags = atsStatus.ats_status_flags;

--- a/src/Vehicle/VehicleAviantFactGroup.cc
+++ b/src/Vehicle/VehicleAviantFactGroup.cc
@@ -197,6 +197,10 @@ void VehicleAviantFactGroup::handleAtsStatusMsg(Vehicle* vehicle, mavlink_messag
         _atsStatusFact.setRawValue(VALUE_DEACT);
         return;
     }
+
+    // If the ATS is enabled, a timeout is critical
+    _atsStatusFact.setTimeoutIndicatorColor(COLOR_CRITICAL);
+
     uint32_t ats_status_flags = atsStatus.ats_status_flags;
     if (!atsStatus.power_loss_trigger_enabled) {
         ats_status_flags &= ~AVIANT_ATS_STATUS_FLAG_POWER_LOSS;


### PR DESCRIPTION
If the ATS is enabled, a telemetry timeout is critical since the ATS will believe the autopilot is inoperative